### PR TITLE
Better CPython symbol handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 
-python: 2.7
+python:
+  - 2.7
+  - 3.4
 
 cache: apt
 

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -43,13 +43,14 @@ def test_read_ranges():
     assert ranges[-5].name == '/lib/x86_64-linux-gnu/libcrypto.so.1.0.0'
     assert ranges[-4].name == '0'
     symbols = ranges[-5].read_object_data(reader=fake_reader)
-    assert symbols == [(18320, '_ufc_setup_salt_r'),
-                       (19936, '_ufc_mk_keytab_r'),
-                       (20464, '_ufc_dofinalperm_r'),
-                       (21040, '_ufc_output_conversion_r'),
-                       (22512, '_ufc_doit_r'),
-                       (2138432, '_ufc_tables_lock'),
-                       (2195840, '_ufc_foobar')]
+    s = ranges[-5].start
+    assert symbols == [(s + 18320, '_ufc_setup_salt_r'),
+                       (s + 19936, '_ufc_mk_keytab_r'),
+                       (s + 20464, '_ufc_dofinalperm_r'),
+                       (s + 21040, '_ufc_output_conversion_r'),
+                       (s + 22512, '_ufc_doit_r'),
+                       (s + 2138432, '_ufc_tables_lock'),
+                       (s + 2195840, '_ufc_foobar')]
 
 
 def test_read_profile(here):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -26,7 +26,7 @@ def test_basic():
     vmprof.enable(tmpfile.fileno())
     function_foo()
     vmprof.disable()
-    assert "function_foo" in  open(tmpfile.name).read()
+    assert b"function_foo" in  open(tmpfile.name, 'rb').read()
 
 def test_enable_disable():
     prof = vmprof.Profiler()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -18,7 +18,7 @@ def get_or_write_libcache(filename):
             d = json.loads(s)
         lib_cache = {}
         for k, v in d.items():
-            lib_cache[k] = LibraryData(*v)
+            lib_cache[k] = LibraryData(v[0], v[1], v[2], v[3], [tuple(x) for x in v[4]])
         return lib_cache
     except (IOError, OSError):
         pass

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,7 +1,12 @@
+import json
+import zlib
 
 import py
-import vmprof, json, time, zlib, json
+import six
+
+import vmprof
 from vmprof.reader import LibraryData
+
 
 def get_or_write_libcache(filename):
     libache_filename = str(py.path.local(__file__).join('..', filename + '.libcache'))
@@ -13,7 +18,7 @@ def get_or_write_libcache(filename):
             d = json.loads(s)
         lib_cache = {}
         for k, v in d.items():
-            lib_cache[k] = LibraryData(v[0], v[1], v[2], v[3], v[4])
+            lib_cache[k] = LibraryData(*v)
         return lib_cache
     except (IOError, OSError):
         pass
@@ -22,11 +27,12 @@ def get_or_write_libcache(filename):
     vmprof.read_profile(path, virtual_only=True,
                         include_extra_info=True, lib_cache=lib_cache)
     d = {}
-    for k, lib in lib_cache.iteritems():
+    for k, lib in six.iteritems(lib_cache):
         d[k] = (lib.name, lib.start, lib.end, lib.is_virtual, lib.symbols)
     with open(libache_filename, "wb") as f:
-        f.write(zlib.compress(json.dumps(d)))
+        f.write(zlib.compress(json.dumps(d).encode('utf-8')))
     return lib_cache
+
 
 def test_read_simple():
     lib_cache = get_or_write_libcache('simple_nested.pypy.prof')

--- a/vmprof/addrspace.py
+++ b/vmprof/addrspace.py
@@ -3,8 +3,11 @@ import bisect
 import six
 
 
-def fmtaddr(x):
-    return '0x%016x' % x
+def fmtaddr(x, name=None):
+    if name:
+        return '0x%016x:%s' % (x, name)
+    else:
+        return '0x%016x' % x
 
 
 class AddressSpace(object):
@@ -39,7 +42,7 @@ class AddressSpace(object):
             return fmtaddr(addr), addr, False, None
         i = bisect.bisect(lib.symbols, (addr + 1,))
         if i > len(lib.symbols) or i <= 0:
-            return fmtaddr(addr), addr, False, None
+            return fmtaddr(addr, lib.name), addr, False, None
         addr, name = lib.symbols[i - 1]
         is_virtual = lib.is_virtual
         return name, addr, is_virtual, lib

--- a/vmprof/cli.py
+++ b/vmprof/cli.py
@@ -9,7 +9,7 @@ def show(stats):
     p.sort(key=lambda x: x[1], reverse=True)
     top = p[0][1]
 
-    max_len = max([len(e[0].split(":")[1]) for e in p])
+    max_len = max([_namelen(e[0]) for e in p])
 
     print(" vmprof output:")
     print(" %:      name:" + " " * (max_len - 3) + "location:")
@@ -24,3 +24,10 @@ def show(stats):
             print(" %s %s %s:%d" % (v.ljust(7), func_name.ljust(max_len + 1), filename, lineno))
         else:
             print(" %s %s" % (v.ljust(7), k.ljust(max_len + 1)))
+
+def _namelen(e):
+    if e.startswith('py:'):
+        return len(e.split(':')[1])
+    else:
+        return len(e)
+

--- a/vmprof/profiler.py
+++ b/vmprof/profiler.py
@@ -31,11 +31,13 @@ def read_profile(prof_filename, lib_cache={}, extra_libs=None,
     period, profiles, virtual_symbols, libs, interp_name = read_prof(prof)
 
     if not virtual_only or include_extra_info:
-        for i, lib in enumerate(libs):
+        exe_name = libs[0].name
+        for lib in libs:
+            executable = lib.name == exe_name
             if lib.name in lib_cache:
-                libs[i].get_symbols_from(lib_cache[lib.name])
+                lib.get_symbols_from(lib_cache[lib.name], executable)
             else:
-                lib.read_object_data(lib.start)
+                lib.read_object_data(executable)
                 lib_cache[lib.name] = lib
     libs.append(
         LibraryData(


### PR DESCRIPTION
```
% python -m vmprof -n x.py
 vmprof output:
 %:      name:                                                  location:
 100.0%  PyEval_EvalCodeEx
 99.9%   PyEval_EvalFrameEx
 99.8%   RunModule
 99.8%   0x0000000000000002
 99.8%   PyObject_Call
 99.8%   0x0000000041dfa016
 99.8%   builtin_exec
 99.8%   _start
 99.8%   PyEval_EvalCode
 99.8%   0x00007fb3d3750ec6:/lib/x86_64-linux-gnu/libc-2.19.so
 99.8%   run_path                                               /home/vagrant/.pyenv/versions/3.4.2/lib/python3.4/runpy.py:216
 99.8%   _run_module_code                                       /home/vagrant/.pyenv/versions/3.4.2/lib/python3.4/runpy.py:88
 99.8%   main
 99.8%   function_call
 99.8%   Py_Main
 99.7%   f                                                      x.py:8
 99.7%   _run_code                                              /home/vagrant/.pyenv/versions/3.4.2/lib/python3.4/runpy.py:62
 99.7%   <module>                                               x.py:1
 56.3%   h                                                      x.py:5
 16.8%   g                                                      x.py:1
 10.4%   PyNumber_InPlaceAdd
 8.1%    x_add
 5.8%    PyFrame_New
 5.7%    _PyDict_LoadGlobal
 5.7%    frame_dealloc
```