### PR TITLE
Don't use lib_cache in test_stat

### DIFF
--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -29,7 +29,8 @@ def get_or_write_libcache(filename):
     return lib_cache
 
 def test_read_simple():
-    lib_cache = get_or_write_libcache('simple_nested.pypy.prof')
+    #lib_cache = get_or_write_libcache('simple_nested.pypy.prof')
+    lib_cache = {}
     path = py.path.local(__file__).join('..', 'simple_nested.pypy.prof')
     stats = vmprof.read_profile(path, virtual_only=True,
                                 include_extra_info=True, lib_cache=lib_cache)


### PR DESCRIPTION
Reproduces errors on #11.

Why get_or_write_libcache() creates gc:minor?