### PR TITLE
Fix KeyError while stats.get_tree()

### DIFF
--- a/vmprof/stats.py
+++ b/vmprof/stats.py
@@ -87,14 +87,18 @@ class Stats(object):
                         next = c
                 top = next
             else:
-                top = top['']
+                try:
+                    top = top['']
+                except KeyError:
+                    return top
+
 
 class Node(object):
     """ children is a dict of addr -> Node
     """
     _self_count = None
     flat = False
-    
+
     def __init__(self, addr, name):
         self.children = {}
         self.name = name
@@ -148,7 +152,7 @@ class Node(object):
         # int -> float -> int losy convertion without
         # any warning
         return [self.name, str(self.addr), self.count, self.meta, chld]
-    
+
     def _rec_count(self):
         c = 1
         for x in six.itervalues(self.children):


### PR DESCRIPTION
When I tried to send my profile to vmprof-server, I encountered following error:

```
    "profiles": stat.get_tree().flatten()._serialize(),
  File "/home/vagrant/vmprof-python/vmprof/stats.py", line 90, in get_tree
    top = top['']
  File "/home/vagrant/vmprof-python/vmprof/stats.py", line 110, in __getitem__
    raise KeyError
KeyError
```

This patch avoids this problem, while I don't know this is correct way or not.