### PR TITLE
Add missing files to source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,2 @@
-recursive-include src/hotpatch *.h
-include src/vmprof.h
-include src/getpc.h
-include src/config.h
-include src/get_custom_offset.c
+recursive-include src *.h *.c
 include src/hotpatch/libdwarf.a


### PR DESCRIPTION
Currently, the following error appears when installing from PyPI.

```
    src/_vmprof.c:11:10: fatal error: 'vmprof_main.h' file not found
    #include "vmprof_main.h"
             ^
    1 error generated.
```