### PR TITLE
Fix #64: set sys.path to match `python foo.py` behaviour

### DIFF
--- a/vmprof/__main__.py
+++ b/vmprof/__main__.py
@@ -55,6 +55,7 @@ def main():
 
     try:
         sys.argv = [args.program] + args.args
+        sys.path.insert(0, os.path.dirname(args.program))
         runpy.run_path(args.program, run_name='__main__')
     except BaseException as e:
         if not isinstance(e, (KeyboardInterrupt, SystemExit)):


### PR DESCRIPTION
Fixes #64.
