### PR TITLE
Speed up parsing of profile files

### DIFF
--- a/vmprof/reader.py
+++ b/vmprof/reader.py
@@ -71,12 +71,12 @@ class JittedCode(int):
     pass
 
 def wrap_kind(kind, pc):
-    cls = {
-        VMPROF_ASSEMBLER_TAG: AssemblerCode,
-        VMPROF_JITTED_TAG: JittedCode,
-        VMPROF_CODE_TAG: lambda x: x,
-    }[kind]
-    return cls(pc)
+    if kind == VMPROF_ASSEMBLER_TAG:
+        return AssemblerCode(pc)
+    elif kind == VMPROF_JITTED_TAG:
+        return JittedCode(pc)
+    assert kind == VMPROF_CODE_TAG
+    return pc
 
 class BufferTooSmallError(Exception):
     def get_buf(self):

--- a/vmprof/reader.py
+++ b/vmprof/reader.py
@@ -4,8 +4,7 @@ import re
 import struct
 import subprocess
 import sys
-from itertools import islice
-from six.moves import zip as izip
+from six.moves import xrange
 
 PY3 = sys.version_info[0] >= 3
 
@@ -35,10 +34,10 @@ def read_trace(fileobj, depth, version):
     if version == VERSION_TAG:
         assert depth & 1 == 0
         depth = depth // 2
-        pcs_and_kinds = read_words(fileobj, depth * 2)
-        kinds = islice(pcs_and_kinds, 0, None, 2)
-        pcs   = islice(pcs_and_kinds, 1, None, 2)
-        return [wrap_kind(kind, pc) for kind, pc in izip(kinds, pcs)]
+        kinds_and_pcs = read_words(fileobj, depth * 2)
+        # kinds_and_pcs is a list of [kind1, pc1, kind2, pc2, ...]
+        return [wrap_kind(kinds_and_pcs[i], kinds_and_pcs[i+1])
+                for i in xrange(len(kinds_and_pcs), None, 2)]
     else:
         return read_words(fileobj, depth)
 

--- a/vmprof/reader.py
+++ b/vmprof/reader.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
+import array
 import re
 import struct
-import array
 import subprocess
 import sys
 from itertools import islice
@@ -19,16 +19,12 @@ def read_word(fileobj):
 
 def read_words(fileobj, nwords):
     """Read `nwords` longs from `fileobj`."""
-    try:
-        # Do we have real file object?
-        fileobj.fileno()
-    except (AttributeError, NotImplementedError):
-        # If not, use slow version
-        b = fileobj.read(WORD_SIZE * nwords)
-        r = [int(w) for w in struct.unpack('l' * nwords, b)]
+    r = array.array('l')
+    b = fileobj.read(WORD_SIZE * nwords)
+    if PY3:
+        r.frombytes(b)
     else:
-        r = array.array('l')
-        r.fromfile(fileobj, nwords)
+        r.fromstring(b)
     return r
 
 def read_string(fileobj):

--- a/vmprof/reader.py
+++ b/vmprof/reader.py
@@ -4,8 +4,8 @@ import struct
 import array
 import subprocess
 import sys
-from itertools import islice, izip
-
+from itertools import islice
+from six.moves import zip as izip
 
 PY3 = sys.version_info[0] >= 3
 


### PR DESCRIPTION
Read multiple words at once if we know the exact number of words to
read.

Speedup on a 60MiB profile:

PyPy:    1.24s vs 0.84s (1.48x)
CPython: 7.85s vs 3.05s (2.57x)