### PR TITLE
Gzip profile files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
   - sudo apt-get install -y libdwarf-dev
   - sudo apt-get install -y libelfg0-dev
   - sudo apt-get install -y libunwind8-dev
+  - sudo apt-get install -y zlib1g-dev
 
 install:
   - pip install .

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ else:
                                'src/vmprof_common.h',
                            ],
                             extra_compile_args=extra_compile_args,
-                            libraries=[])]
+                            libraries=['z'])]
    
 
 setup(

--- a/src/vmprof_common.h
+++ b/src/vmprof_common.h
@@ -1,8 +1,9 @@
 #include <stddef.h>
+#include <zlib.h>
 
 #define MAX_FUNC_NAME 1024
 
-static int profile_file = -1;
+static gzFile profile_file = NULL;
 static long prepare_interval_usec = 0;
 static long profile_interval_usec = 0;
 static int opened_profile(char *interp_name, int memory);
@@ -51,9 +52,9 @@ char *vmprof_init(int fd, double interval, int memory, char *interp_name)
         return "memory tracking not supported on non-linux";
 #endif
     assert(fd >= 0);
-    profile_file = fd;
+    profile_file = gzdopen(dup(fd), "ab3");
     if (opened_profile(interp_name, memory) < 0) {
-        profile_file = -1;
+        profile_file = NULL;
         return strerror(errno);
     }
     return NULL;

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,10 +1,10 @@
 
 """ Test the actual run
 """
-
 import py
 import sys
 import tempfile
+import gzip
 import vmprof
 from vmprof.reader import read_prof_bit_by_bit
 from vmprof.stats import Stats
@@ -19,7 +19,7 @@ if '__pypy__' in sys.builtin_module_names:
     COUNT = 100000
 else:
     COUNT = 10000
-    
+
 def function_foo():
     for k in range(1000):
         l = [a for a in xrange(COUNT)]
@@ -42,7 +42,7 @@ def test_basic():
     function_foo()
     vmprof.disable()
     tmpfile.close()
-    assert b"function_foo" in open(tmpfile.name, 'rb').read()
+    assert b"function_foo" in gzip.GzipFile(tmpfile.name).read()
 
 def test_read_bit_by_bit():
     tmpfile = tempfile.NamedTemporaryFile(delete=False)

--- a/vmprof/reader.py
+++ b/vmprof/reader.py
@@ -4,8 +4,8 @@ import struct
 import array
 import subprocess
 import sys
-from itertools import islice, izip
-
+from itertools import islice
+from six.moves import zip as izip
 
 PY3 = sys.version_info[0] >= 3
 

--- a/vmprof/reader.py
+++ b/vmprof/reader.py
@@ -203,6 +203,11 @@ def read_prof(fileobj, virtual_ips_only=False): #
     interp_name = None
     version = 0
 
+    # Optimization: Save a lot of memory by explicitly caching IP integers.
+    # This works around the fact that integers, albeit equivalent, are usually
+    # allocated to different actual memory objects by Python.
+    integer_cache = {}
+
     while True:
         marker = fileobj.read(1)
         if marker == MARKER_HEADER:
@@ -223,6 +228,7 @@ def read_prof(fileobj, virtual_ips_only=False): #
                 trace = []
             else:
                 trace = read_trace(fileobj, depth, version)
+                trace = [integer_cache.setdefault(x, x) for x in trace]
             if version >= VERSION_THREAD_ID:
                 thread_id, = struct.unpack('l', fileobj.read(WORD_SIZE))
             else:


### PR DESCRIPTION
Depends on #70 

Gzip profile files, reduces file size up to 97%. Backwards compatible. Increases parse duration by about 5-10%. (Note that my other PR reduces parse duration by 150-250%.)

I also tried other file size reduction techniques:

- Use 16-bit integer for instruction pointers instead of 32-bit ones (`short` instead of `long`). Map 32-bit IPs to 16-bit IPs using an associative array when writing the profile. This works well and isn't too difficult to implement. It cuts profile file size up to 50%.
- Count repeated IPs within a trace (recursion etc.) and replace by a `(IP, count)` tuple. Easy to implement, saves 10% in my benchmarks (depends on the program that is being profiled of course)

An idea I did not look into is de-duplicating whole traces, i.e. for each trace look if an equivalent trace has already been written and if so only use a pointer to that other trace.

Gzipping everything is probably the easiest and most robust solution to reducing file sizes.