### PR TITLE
Remove pytest-runner from setup-requires to fix setup.py on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         'requests',
         'six',
     ],
-    setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
It seems that easy install can't install pytest-runner on Windows:

distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('pytest-runner')