### PR TITLE
Fixed PyThreadState getter

### DIFF
--- a/src/vmprof_common.h
+++ b/src/vmprof_common.h
@@ -136,9 +136,9 @@ PyThreadState * get_current_thread_state(void)
 {
 #if PY_MAJOR_VERSION < 3
     return _PyThreadState_Current;
-#elif PY_VERSION_HEX < 0x03050000
+#elif PY_VERSION_HEX < 0x03050200
     return (PyThreadState*) _Py_atomic_load_relaxed(&_PyThreadState_Current);
 #else
-    return PyThreadState_GET();
+    return _PyThreadState_UncheckedGet();
 #endif
 }

--- a/src/vmprof_common.h
+++ b/src/vmprof_common.h
@@ -132,19 +132,13 @@ static int opened_profile(char *interp_name, int memory, int lines)
     return _write_all((char*)&header, 5 * sizeof(long) + 5 + namelen);
 }
 
-// for whatever reason python-dev decided to hide that one
-#if PY_MAJOR_VERSION >= 3 && !defined(_Py_atomic_load_relaxed)
-                                 /* this was abruptly un-defined in 3.5.1 */
-    extern void *volatile _PyThreadState_Current;
-       /* XXX simple volatile access is assumed atomic */
-#  define _Py_atomic_load_relaxed(pp)  (*(pp))
-#endif
- 
-PyThreadState* get_current_thread_state(void)
+PyThreadState * get_current_thread_state(void)
 {
-#if PY_MAJOR_VERSION >= 3
-    return (PyThreadState*)_Py_atomic_load_relaxed(&_PyThreadState_Current);
-#else
+#if PY_MAJOR_VERSION < 3
     return _PyThreadState_Current;
+#elif PY_VERSION_HEX < 0x03050000
+    return (PyThreadState*) _Py_atomic_load_relaxed(&_PyThreadState_Current);
+#else
+    return PyThreadState_GET();
 #endif
 }


### PR DESCRIPTION
Tested on:
  - Windows (7-SP2): 2.7, 3.4, 3.5.0, 3.5.1, 3.5.2
  - Linux (Travis): 2.7, 3.4, 3.5.0, 3.5.1, 3.5.2

Closes #92
