### PR TITLE
Fix authorization header removing content-type header

### DIFF
--- a/vmshare/service.py
+++ b/vmshare/service.py
@@ -50,7 +50,7 @@ class Service(object):
     def get_headers(self):
         base_headers = { 'Content-Type': 'application/json' }
         if self.auth:
-            base_headers = {'AUTHORIZATION': "Token %s" % self.auth}
+            base_headers['AUTHORIZATION'] = "Token %s" % self.auth
         if self.csrf_token:
             base_headers['csrftoken'] = self.csrf_token
         return base_headers


### PR DESCRIPTION
Using --web-auth causes the following error when submitting profiles:

    server rejected meta data. status: 415, msg: '{"detail":"Unsupported media type \"text/plain\" in request.}'

This is due to content-type header being replaced by AUTHORIZATION header