### PR TITLE
Fix a define that prevents _vmprof_sample_stack() to work with PyPy

### DIFF
--- a/src/vmprof_main.h
+++ b/src/vmprof_main.h
@@ -218,7 +218,7 @@ static void sigprof_handler(int sig_nr, siginfo_t* info, void *ucontext)
         if (p == NULL) {
             /* ignore this signal: there are no free buffers right now */
         } else {
-#ifdef RPYTHON_VMPORF
+#ifdef RPYTHON_VMPROF
             commit = _vmprof_sample_stack(p, NULL, (ucontext_t*)ucontext);
 #else
             commit = _vmprof_sample_stack(p, tstate, (ucontext_t*)ucontext);


### PR DESCRIPTION
While looking at the vmprof internals and how it works, I've found a wrong #ifdef that prevents calling the right _vmprof_sample_stack() function for PyPy.