### PR TITLE
Optional real time profiling support.

### DIFF
--- a/src/vmprof.h
+++ b/src/vmprof.h
@@ -26,6 +26,7 @@
 #define PROFILE_LINES  '\x02'
 #define PROFILE_NATIVE '\x04'
 #define PROFILE_RPYTHON '\x08'
+#define PROFILE_REAL_TIME '\x10'
 
 #define DYN_JIT_FLAG 0xbeefbeef
 

--- a/src/vmprof_common.h
+++ b/src/vmprof_common.h
@@ -12,6 +12,10 @@
 #include "vmprof_mt.h"
 #endif
 
+#ifdef VMPROF_LINUX
+#include <syscall.h>
+#endif
+
 #define MAX_FUNC_NAME 1024
 
 static long prepare_interval_usec = 0;
@@ -22,6 +26,7 @@ static int opened_profile(const char *interp_name, int memory, int proflines, in
 #ifdef VMPROF_UNIX
 static int signal_type = SIGPROF;
 static int itimer_type = ITIMER_PROF;
+static pid_t original_tid = 0;
 static struct profbuf_s *volatile current_codes;
 #endif
 
@@ -79,6 +84,9 @@ char *vmprof_init(int fd, double interval, int memory,
     if (real_time) {
         signal_type = SIGALRM;
         itimer_type = ITIMER_REAL;
+#if VMPROF_LINUX
+        original_tid = (pid_t) syscall(SYS_gettid);
+#endif
     } else {
         signal_type = SIGPROF;
         itimer_type = ITIMER_PROF;

--- a/src/vmprof_common.h
+++ b/src/vmprof_common.h
@@ -26,27 +26,27 @@ static int opened_profile(const char *interp_name, int memory, int proflines, in
 #ifdef VMPROF_UNIX
 static int signal_type = SIGPROF;
 static int itimer_type = ITIMER_PROF;
-static pid_t *threads = NULL;
+static pthread_t *threads = NULL;
 static size_t threads_size = 0;
 static size_t thread_count = 0;
 static size_t threads_size_step = 8;
 static struct profbuf_s *volatile current_codes;
 #endif
 
-#ifdef VMPROF_LINUX
+#ifdef VMPROF_UNIX
 
-static inline ssize_t search_thread(pid_t tid, ssize_t i) {
+static inline ssize_t search_thread(pthread_t tid, ssize_t i) {
     if (i < 0)
         i = 0;
     while (i < thread_count) {
-        if (threads[i] == tid)
+        if (pthread_equal(threads[i], tid))
             return i;
         i++;
     }
     return -1;
 }
 
-ssize_t insert_thread(pid_t tid, ssize_t i) {
+ssize_t insert_thread(pthread_t tid, ssize_t i) {
     assert(signal_type == SIGALRM);
     i = search_thread(tid, i);
     if (i > 0)
@@ -61,7 +61,7 @@ ssize_t insert_thread(pid_t tid, ssize_t i) {
     return thread_count;
 }
 
-ssize_t remove_thread(pid_t tid, ssize_t i) {
+ssize_t remove_thread(pthread_t tid, ssize_t i) {
     assert(signal_type == SIGALRM);
     if (thread_count == 0)
         return -1;

--- a/src/vmprof_main.h
+++ b/src/vmprof_main.h
@@ -184,26 +184,30 @@ static PY_THREAD_STATE_T * _get_pystate_for_this_thread(void) {
 }
 #endif
 
+#ifdef VMPROF_LINUX
+static int broadcast_signal_for_threads(pid_t pid)
+{
+    int done = 1;
+    size_t i = 0;
+    pid_t tid;
+    while (i < thread_count) {
+        tid = threads[i];
+        if (tid == pid)
+            done = 0;
+        else
+        if (syscall(SYS_tgkill, pid, tid, SIGALRM))
+            remove_thread(tid, i);
+        i++;
+    }
+    return done;
+}
+#endif
+
 static void sigprof_handler(int sig_nr, siginfo_t* info, void *ucontext)
 {
     int commit;
     PY_THREAD_STATE_T * tstate = NULL;
     void (*prevhandler)(int);
-
-#ifdef VMPROF_LINUX
-    pid_t pid = getpid();
-    pid_t tid = (pid_t) syscall(SYS_gettid);
-
-    // SIGNAL ABUSE AHEAD
-    // On linux, the prof timer will deliver the signal to the thread which triggered the timer,
-    // because these timers are based on process and system time, and as such, are thread-aware.
-    // For the real timer, the signal gets delivered to the main thread, seemingly always.
-    // Consequently if we want to sample the original thread, we may need to forward the signal.
-    if ((signal_type == SIGALRM) && (tid != original_tid)) {
-        syscall(SYS_tgkill, pid, original_tid, SIGALRM);
-        return;
-    }
-#endif
 
 #ifndef RPYTHON_VMPROF
     // TERRIBLE HACK AHEAD
@@ -218,6 +222,23 @@ static void sigprof_handler(int sig_nr, siginfo_t* info, void *ucontext)
     // get_current_thread_state returns a sane result
     while (__sync_lock_test_and_set(&spinlock, 1)) {
     }
+
+#ifdef VMPROF_LINUX
+    // SIGNAL ABUSE AHEAD
+    // On linux, the prof timer will deliver the signal to the thread which triggered the timer,
+    // because these timers are based on process and system time, and as such, are thread-aware.
+    // For the real timer, the signal gets delivered to the main thread, seemingly always.
+    // Consequently if we want to sample multiple threads, we need to forward this signal.
+    if (signal_type == SIGALRM) {
+        pid_t pid = getpid();
+        pid_t tid = (pid_t) syscall(SYS_gettid);
+        if ((pid == tid) && broadcast_signal_for_threads(pid)) {
+            __sync_lock_release(&spinlock);
+            return;
+        }
+    }
+#endif
+
     prevhandler = signal(SIGSEGV, &segfault_handler);
     int fault_code = setjmp(restore_point);
     if (fault_code == 0) {
@@ -380,7 +401,7 @@ static void disable_cpyprof(void)
 #endif
 
 RPY_EXTERN
-int vmprof_enable(int memory, int native)
+int vmprof_enable(int memory, int native, int real_time)
 {
 #ifdef VMP_SUPPORTS_NATIVE_PROFILING
     init_cpyprof(native);
@@ -390,6 +411,10 @@ int vmprof_enable(int memory, int native)
     profile_interval_usec = prepare_interval_usec;
     if (memory && setup_rss() == -1)
         goto error;
+#if VMPROF_LINUX
+    if (real_time && insert_thread((pid_t)syscall(SYS_gettid), -1) == -1)
+        goto error;
+#endif
     if (install_pthread_atfork_hooks() == -1)
         goto error;
     if (install_sigprof_handler() == -1)
@@ -435,6 +460,10 @@ int vmprof_disable(void)
         return -1;
     if (remove_sigprof_handler() == -1)
         return -1;
+#ifdef VMPROF_LINUX
+    if ((signal_type == SIGALRM) && remove_threads() == -1)
+        return -1;
+#endif
     flush_codes();
     if (shutdown_concurrent_bufs(vmp_profile_fileno()) < 0)
         return -1;

--- a/src/vmprof_main.h
+++ b/src/vmprof_main.h
@@ -193,11 +193,11 @@ static int broadcast_signal_for_threads(void)
     pthread_t tid;
     while (i < thread_count) {
         tid = threads[i];
-        if (pthread_equal(tid, self))
+        if (pthread_equal(tid, self)) {
             done = 0;
-        else
-        if (pthread_kill(tid, SIGALRM))
+        } else if (pthread_kill(tid, SIGALRM)) {
             remove_thread(tid, i);
+        }
         i++;
     }
     return done;

--- a/src/vmprof_main_win32.h
+++ b/src/vmprof_main_win32.h
@@ -160,7 +160,7 @@ long __stdcall vmprof_mainloop(void *arg)
 }
 
 RPY_EXTERN
-int vmprof_enable(int memory, int native)
+int vmprof_enable(int memory, int native, int real_time)
 {
     if (!thread_started) {
         if (!CreateThread(NULL, 0, vmprof_mainloop, NULL, 0, NULL)) {

--- a/vmprof/__init__.py
+++ b/vmprof/__init__.py
@@ -66,12 +66,12 @@ if IS_PYPY:
             _vmprof.enable(gz_fileno, period) # , memory, lines, native)
 else:
     # CPYTHON
-    def enable(fileno, period=DEFAULT_PERIOD, memory=False, lines=False, native=None):
+    def enable(fileno, period=DEFAULT_PERIOD, memory=False, lines=False, native=None, real_time=False):
         if not isinstance(period, float):
             raise ValueError("You need to pass a float as an argument")
         gz_fileno = _gzip_start(fileno)
         native = _is_native_enabled(native)
-        _vmprof.enable(gz_fileno, period, memory, lines, native)
+        _vmprof.enable(gz_fileno, period, memory, lines, native, real_time)
 
     def sample_stack_now(skip=0):
         """ Helper utility mostly for tests, this is considered

--- a/vmprof/__init__.py
+++ b/vmprof/__init__.py
@@ -47,7 +47,7 @@ def _is_native_enabled(native):
     return native
 
 if IS_PYPY:
-    def enable(fileno, period=DEFAULT_PERIOD, memory=False, lines=False, native=None, warn=True):
+    def enable(fileno, period=DEFAULT_PERIOD, memory=False, lines=False, native=None, real_time=False, warn=True):
         pypy_version_info = sys.pypy_version_info[:3]
         if not isinstance(period, float):
             raise ValueError("You need to pass a float as an argument")
@@ -61,7 +61,7 @@ if IS_PYPY:
         native = _is_native_enabled(native)
         gz_fileno = _gzip_start(fileno)
         if pypy_version_info >= (5, 8, 0):
-            _vmprof.enable(gz_fileno, period, memory, lines, native)
+            _vmprof.enable(gz_fileno, period, memory, lines, native, real_time)
         else:
             _vmprof.enable(gz_fileno, period) # , memory, lines, native)
 else:
@@ -89,6 +89,21 @@ else:
             Only considers linking symbols found by dladdr.
         """
         return _vmprof.resolve_addr(addr)
+
+
+def insert_real_time_thread():
+    """ Inserts a thread into the list of threads to be sampled in real time mode.
+        When enabling real time mode, the caller thread is inserted automatically.
+        Returns the number of registered threads, or -1 if we can't insert thread.
+    """
+    return _vmprof.insert_real_time_thread()
+
+def remove_real_time_thread():
+    """ Removes a thread from the list of threads to be sampled in real time mode.
+        When disabling in real time mode, *all* threads are removed automatically.
+        Returns the number of registered threads, or -1 if we can't remove thread.
+    """
+    return _vmprof.remove_real_time_thread()
 
 
 def is_enabled():

--- a/vmprof/profiler.py
+++ b/vmprof/profiler.py
@@ -11,20 +11,21 @@ class VMProfError(Exception):
 class ProfilerContext(object):
     done = False
 
-    def __init__(self, name, memory, native, only_needed, real_time):
+    def __init__(self, name, period, memory, native, only_needed, real_time):
         if name is None:
             self.tmpfile = tempfile.NamedTemporaryFile("w+b", delete=False)
         else:
             self.tmpfile = open(name, "w+b")
         self.filename = self.tmpfile.name
+        self.period = period
         self.memory = memory
         self.native = native
         self.only_needed = only_needed
         self.real_time = real_time
 
     def __enter__(self):
-        vmprof.enable(self.tmpfile.fileno(), 0.001, self.memory, native=self.native,
-                      real_time=self.real_time)
+        vmprof.enable(self.tmpfile.fileno(), self.period, self.memory,
+                      native=self.native, real_time=self.real_time)
 
     def __exit__(self, type, value, traceback):
         vmprof.disable(only_needed=self.only_needed)
@@ -56,8 +57,8 @@ class Profiler(object):
     def __init__(self):
         self._lib_cache = {}
 
-    def measure(self, name=None, memory=False, native=False, only_needed=False, real_time=False):
-        self.ctx = ProfilerContext(name, memory, native, real_time, only_needed)
+    def measure(self, name=None, period=0.001, memory=False, native=False, only_needed=False, real_time=False):
+        self.ctx = ProfilerContext(name, period, memory, native, only_needed, real_time)
         return self.ctx
 
     def get_stats(self):

--- a/vmprof/profiler.py
+++ b/vmprof/profiler.py
@@ -11,7 +11,7 @@ class VMProfError(Exception):
 class ProfilerContext(object):
     done = False
 
-    def __init__(self, name, memory, native, only_needed):
+    def __init__(self, name, memory, native, only_needed, real_time):
         if name is None:
             self.tmpfile = tempfile.NamedTemporaryFile("w+b", delete=False)
         else:
@@ -20,9 +20,11 @@ class ProfilerContext(object):
         self.memory = memory
         self.native = native
         self.only_needed = only_needed
+        self.real_time = real_time
 
     def __enter__(self):
-        vmprof.enable(self.tmpfile.fileno(), 0.001, self.memory, native=self.native)
+        vmprof.enable(self.tmpfile.fileno(), 0.001, self.memory, native=self.native,
+                      real_time=self.real_time)
 
     def __exit__(self, type, value, traceback):
         vmprof.disable(only_needed=self.only_needed)
@@ -54,8 +56,8 @@ class Profiler(object):
     def __init__(self):
         self._lib_cache = {}
 
-    def measure(self, name=None, memory=False, native=False, only_needed=False):
-        self.ctx = ProfilerContext(name, memory, native, only_needed)
+    def measure(self, name=None, memory=False, native=False, only_needed=False, real_time=False):
+        self.ctx = ProfilerContext(name, memory, native, real_time, only_needed)
         return self.ctx
 
     def get_stats(self):

--- a/vmprof/test/test_run.py
+++ b/vmprof/test/test_run.py
@@ -257,7 +257,7 @@ def test_memory_measurment():
     prof.get_stats()
 
 
-@py.test.mark.skipif("sys.platform != 'linux'")
+@py.test.mark.skipif("sys.platform == 'win32'")
 def test_vmprof_real_time():
     prof = vmprof.Profiler()
     with prof.measure(real_time=True):
@@ -269,7 +269,7 @@ def test_vmprof_real_time():
 
 
 @py.test.mark.skipif("'__pypy__' in sys.builtin_module_names")
-@py.test.mark.skipif("sys.platform != 'linux'")
+@py.test.mark.skipif("sys.platform == 'win32'")
 @py.test.mark.parametrize("insert_foo,remove_bar", [
     (False, False),
     (False,  True),


### PR DESCRIPTION
TL;DR: `time.sleep()` or waiting on IO can be detected now.

Rationale: vmprof is an excellent low-overhead profiler, but sometimes what we really want is to measure real time usage of the process, to detect situations when we're waiting for something else to happen.

That's especially handy when it comes to optimizing your code at a high-level, when the bottleneck is not in the Python code itself, but in the way it interacts with the rest of the system. Similarly, for that use case we want to sample all the threads, not just the thread that's currently running.

(Exact analysis of thread behaviour can be done downstream, because vmprof is already saving the thread ID for every stack snapshot.)

I'd love to support OSX, but I don't have a machine to test its signal behaviour.

Cheers!