### PR TITLE
Allow checking vmprof output in progress.

### DIFF
--- a/vmprof/stats.py
+++ b/vmprof/stats.py
@@ -14,10 +14,12 @@ class Stats(object):
         if state:
             self.profile_lines = state.profile_lines
             self.profile_memory = state.profile_memory
+            self.adr_size = len(state.virtual_ips)
         else:
             # unkown, for tests only
-            self.profile_lines = False
-            self.profile_memory = False
+            self.profile_lines = None
+            self.profile_memory = None
+            self.adr_size = None
         self.generate_top()
         if jit_frames is None:
             jit_frames = set()

--- a/vmprof/test/test_run.py
+++ b/vmprof/test/test_run.py
@@ -161,9 +161,14 @@ def test_only_needed():
     with prof.measure(only_needed=True):
         function_foo()
     stats_two = prof.get_stats()
+    with prof.measure(only_needed=True):
+        vmprof._vmprof.write_all_code_objects()
+        function_foo()
+    stats_all = prof.get_stats()
     assert foo_full_name in stats_one.adr_dict.values()
     assert foo_full_name in stats_two.adr_dict.values()
     assert len(stats_one.adr_dict) > len(stats_two.adr_dict)
+    assert stats_one.adr_size == stats_all.adr_size
 
 def test_nested_call():
     prof = vmprof.Profiler()


### PR DESCRIPTION
This PR isn't quite ready yet, but I thought I'd start early, then we can talk about the preferred approach as \I'm hacking away. Related to #127.

Two improvements are made so far:
1. Make the reader interface a little bit more abstract.
2. When writing out only needed symbols, don't write the same symbol multiple times.

Reasoning:
1. As a next step, we can have a far simpler implementation when it comes to handling incomplete profile reads - which we'll need if we want to be able to query an ongoing profiling run.
2. To have those in-progress reads actually useful, we'll need to be able to force a symbol write before the profile is actually closed. The function for this is already exposed to the Python layer, even though it's not mentioned in the main docs. I haven't selected a way of doing that yet, but once that is in place, we definitely don't want to be forced to repeatedly write out the same virtual ips over and over again.

The current implementation of (2) seems slightly iffy to me, is it okay to use a PySet here, or should this be ported over to the khash thing? Any other comments? ;)