### PR TITLE
make sure it works on pypy 5.8

### DIFF
--- a/vmprof/__init__.py
+++ b/vmprof/__init__.py
@@ -66,8 +66,12 @@ if IS_PYPY:
         # TODO fixes currently released pypy's
         native = _is_native_enabled(native)
         gz_fileno = _gzip_start(fileno)
-        if pypy_version_info >= (5, 8, 0):
+        #
+        # use the actual version number as soon as we implement real_time in pypy
+        if pypy_version_info >= (999, 0, 0):
             _vmprof.enable(gz_fileno, period, memory, lines, native, real_time)
+        if pypy_version_info >= (5, 8, 0):
+            _vmprof.enable(gz_fileno, period, memory, lines, native)
         else:
             _vmprof.enable(gz_fileno, period) # , memory, lines, native)
 else:


### PR DESCRIPTION
this fixes it for now. But I wonder whether we should switch to a more robust way of specifying options: e.g., we could pass them in a dictionary and then the backend can ignore the ones if doesn't know about (and in that case we also need a way to *know* which are the options the backend knows about, to be able to emit the correct warnings)