### PR TITLE
Freebsd Fixes

### DIFF
--- a/src/machine.c
+++ b/src/machine.c
@@ -28,7 +28,7 @@ const char * vmp_machine_os_name(void)
 #elif __linux__
     return "linux";
 #elif __FreeBSD__
-    return "freebsd"
+    return "freebsd";
 #else
     #error "Unknown compiler"
 #endif

--- a/src/vmp_stack.c
+++ b/src/vmp_stack.c
@@ -29,6 +29,7 @@ static int (*unw_get_proc_name)(unw_cursor_t *, char *, size_t, unw_word_t*) = N
 static int (*unw_is_signal_frame)(unw_cursor_t *) = NULL;
 static int (*unw_getcontext)(unw_context_t *) = NULL;
 #else
+#define UNW_LOCAL_ONLY
 #include <libunwind.h>
 #endif
 


### PR DESCRIPTION
The following changes are required to get pypy 5.9 compiling on FreeBSD (see https://bitbucket.org/pypy/pypy/issues/2697/patch-fix-compilation-on-freebsd).  