### PR TITLE
BUG: Gcc warnings

### DIFF
--- a/src/vmp_stack.c
+++ b/src/vmp_stack.c
@@ -262,7 +262,7 @@ int vmp_walk_and_record_stack(PY_STACK_FRAME_T *frame, void ** result,
     }
 
     int depth = 0;
-    PY_STACK_FRAME_T * top_most_frame = frame;
+    //PY_STACK_FRAME_T * top_most_frame = frame;
     while ((depth + _per_loop()) <= max_depth) {
         unw_get_proc_info(&cursor, &pip);
 
@@ -400,7 +400,7 @@ int vmp_read_vmaps(const char * fname) {
     if (fd == NULL) {
         return 0;
     }
-    char * saveptr;
+    char * saveptr = NULL;
     char * line = NULL;
     char * he = NULL;
     char * name;

--- a/src/vmprof_common.c
+++ b/src/vmprof_common.c
@@ -4,6 +4,9 @@
 #include <errno.h>
 
 #ifdef RPYTHON_VMPROF
+
+int get_stack_trace(PY_THREAD_STATE_T * current, void** result, int max_depth, intptr_t pc);
+
 #ifdef RPYTHON_LL2CTYPES
    /* only for testing: ll2ctypes sets RPY_EXTERN from the command-line */
 
@@ -193,7 +196,7 @@ PY_STACK_FRAME_T *get_vmprof_stack(void)
 #endif
 
 intptr_t vmprof_get_traceback(void *stack, void *ucontext,
-                              intptr_t *result_p, intptr_t result_length)
+                              void **result_p, intptr_t result_length)
 {
     int n;
     int enabled;

--- a/src/vmprof_common.h
+++ b/src/vmprof_common.h
@@ -96,7 +96,7 @@ PY_STACK_FRAME_T *get_vmprof_stack(void);
 #endif
 RPY_EXTERN
 intptr_t vmprof_get_traceback(void *stack, void *ucontext,
-                              intptr_t *result_p, intptr_t result_length);
+                              void **result_p, intptr_t result_length);
 #endif
 
 int vmprof_get_signal_type(void);

--- a/vmprof/test/test_c_source.py
+++ b/vmprof/test/test_c_source.py
@@ -10,7 +10,7 @@ class TestStack(object):
     def setup_class(cls):
         stack_ffi = FFI()
         stack_ffi.cdef("""
-        typedef uint64_t ptr_t;
+        typedef intptr_t ptr_t;
         int vmp_binary_search_ranges(ptr_t ip, ptr_t * l, int count);
         int vmp_ignore_ip(ptr_t ip);
         int vmp_ignore_symbol_count(void);
@@ -28,7 +28,7 @@ class TestStack(object):
             stack_ffi.set_source("vmprof.test._test_stack", source, include_dirs=['src'],
                                  define_macros=[('_CFFI_USE_EMBEDDING',1), ('PY_TEST',1),
                                                 ('VMP_SUPPORTS_NATIVE_PROFILING',1)],
-                                 libraries=libs, extra_compile_args=['-g'])
+                                 libraries=libs, extra_compile_args=['-Werror', '-g'])
 
         stack_ffi.compile(verbose=True)
         from vmprof.test import _test_stack as clib

--- a/vmprof/test/test_c_symboltable.py
+++ b/vmprof/test/test_c_symboltable.py
@@ -23,8 +23,8 @@ if sys.platform != 'win32':
     {
         *name = gname;
         *src = gsrc;
-        gname[0] = '\x00';
-        gsrc[0] = '\x00';
+        gname[0] = 0;
+        gsrc[0] = 0;
         return vmp_resolve_addr(&vmp_resolve_addr, gname, 64,
                                 lineno, gsrc, 128);
     }
@@ -32,8 +32,8 @@ if sys.platform != 'win32':
     {
         *name = gname;
         *src = gsrc;
-        gname[0] = '\x00';
-        gsrc[0] = '\x00';
+        gname[0] = 0;
+        gsrc[0] = 0;
         return vmp_resolve_addr(&abs, gname, 64,
                                 lineno, gsrc, 128);
     }
@@ -57,7 +57,7 @@ if sys.platform != 'win32':
 
     extra_compile = []
     if sys.platform.startswith("linux"):
-        extra_compile = ['-DVMPROF_LINUX', '-DVMPROF_UNIX']
+        extra_compile = ['-DVMPROF_LINUX', '-DVMPROF_UNIX', '-Werror', '-g']
 
     # trick: compile with _CFFI_USE_EMBEDDING=1 which will not define Py_LIMITED_API
     ffi.set_source("vmprof.test._test_symboltable", source, include_dirs=includes,

--- a/vmprof/test/test_run.py
+++ b/vmprof/test/test_run.py
@@ -398,13 +398,13 @@ class TestNative(object):
     def setup_class(cls):
         ffi = FFI()
         ffi.cdef("""
-        void native_gzipgzipgzip();
+        void native_gzipgzipgzip(void);
         """)
         source = """
         #include "zlib.h"
         unsigned char input[100];
         unsigned char output[100];
-        void native_gzipgzipgzip() {
+        void native_gzipgzipgzip(void) {
             z_stream defstream;
             defstream.zalloc = Z_NULL;
             defstream.zfree = Z_NULL;
@@ -429,7 +429,7 @@ class TestNative(object):
         # trick: compile with _CFFI_USE_EMBEDDING=1 which will not define Py_LIMITED_API
         ffi.set_source("vmprof.test._test_native_gzip", source, include_dirs=['src'],
                        define_macros=[('_CFFI_USE_EMBEDDING',1),('_PY_TEST',1)], libraries=libs,
-                       extra_compile_args=['-g', '-O0'])
+                       extra_compile_args=['-Werror', '-g', '-O0'])
 
         ffi.compile(verbose=True)
         from vmprof.test import _test_native_gzip as clib


### PR DESCRIPTION
enable -Werror and fix warnings, also fix warning in rpython-only code. 

Perhaps this function should be moved to the rpython repo?