### PR TITLE
Ensuring adr_dict is split correctly

### DIFF
--- a/vmprof/stats.py
+++ b/vmprof/stats.py
@@ -43,7 +43,7 @@ class Stats(object):
 
     def find_addrs_containing_name(self, part):
         for adr, name in self.adr_dict.items():
-            n, symbol, _, _ = name.split(':')
+            n, symbol, _, _ = name.split(':', 3)
             if part in symbol:
                 yield adr
 
@@ -51,7 +51,7 @@ class Stats(object):
         name = self.adr_dict.get(addr, None)
         if not name:
             return None
-        lang, symbol, line, file = name.split(':')
+        lang, symbol, line, file = name.split(':', 3)
         return lang, symbol, line, file
 
     def getargv(self):


### PR DESCRIPTION
Normally the dictionary adr_dict contains lines with four components
all separated by a colon (:). In the case of generated code the last
component may contain the generated code instead of the filename of the
file where the code resides. Since generated code most likely will
contain at least one colon the full line will contain more than the
expected three colons resulting in a 'too many values to unpack' error.

To ensure that this string can always be safely split the 'maxsplit'
parameter should be set to 3.