### PR TITLE
Use PyFrame_GetLineNumber to get line numbers

### DIFF
--- a/src/vmp_stack.c
+++ b/src/vmp_stack.c
@@ -93,7 +93,7 @@ static PY_STACK_FRAME_T * _write_python_stack_entry(PY_STACK_FRAME_T * frame, vo
 
         // NOTE: the profiling overhead can be reduced by storing co_lnotab in the dump and
         // moving this computation to the reader instead of doing it here.
-        result[*depth] = (void*) PyFrame_GetLineNumber(frame);
+        result[*depth] = (void*) (int64_t) PyFrame_GetLineNumber(frame);
         *depth = *depth + 1;
     }
     result[*depth] = (void*)CODE_ADDR_TO_UID(FRAME_CODE(frame));

--- a/src/vmp_stack.c
+++ b/src/vmp_stack.c
@@ -82,12 +82,6 @@ int vmp_profiles_python_lines(void) {
 
 static PY_STACK_FRAME_T * _write_python_stack_entry(PY_STACK_FRAME_T * frame, void ** result, int * depth, int max_depth)
 {
-    int len;
-    int addr;
-    int j;
-    uint64_t line;
-    char *lnotab;
-
 #ifndef RPYTHON_VMPROF // pypy does not support line profiling
     if (vmp_profiles_python_lines()) {
         // In the line profiling mode we save a line number for every frame.
@@ -99,27 +93,8 @@ static PY_STACK_FRAME_T * _write_python_stack_entry(PY_STACK_FRAME_T * frame, vo
 
         // NOTE: the profiling overhead can be reduced by storing co_lnotab in the dump and
         // moving this computation to the reader instead of doing it here.
-        lnotab = PyStr_AS_STRING(frame->f_code->co_lnotab);
-
-        if (lnotab != NULL) {
-            line = (uint64_t)frame->f_lineno;
-            addr = 0;
-
-            len = (int)PyStr_GET_SIZE(frame->f_code->co_lnotab);
-
-            for (j = 0; j < len; j += 2) {
-                addr += lnotab[j];
-                if (addr > frame->f_lasti) {
-                    break;
-                }
-                line += lnotab[j+1];
-            }
-            result[*depth] = (void*) line;
-            *depth = *depth + 1;
-        } else {
-            result[*depth] = (void*) 0;
-            *depth = *depth + 1;
-        }
+        result[*depth] = (void*) PyFrame_GetLineNumber(frame);
+        *depth = *depth + 1;
     }
     result[*depth] = (void*)CODE_ADDR_TO_UID(FRAME_CODE(frame));
     *depth = *depth + 1;


### PR DESCRIPTION
In Python 2, the line offsets in `co_lnotab` are unsigned bytes (see: [Python2](https://github.com/python/cpython/blob/2.7/Objects/codeobject.c#L699-L711) vs. [Python3](https://github.com/python/cpython/blob/3.7/Objects/codeobject.c#L773) implementations of Addr2Line). The code for resolving the line in vmprof assumes that they are `signed char`. This leads to invalid profiles with negative line numbers (see e.g. the minimal repro in #154).

This change updates the code to instead use `PyFrame_GetLineNumber`, which is available in the runtime since Python >=2.7 so that we don't need to reimplement it here.

Fixes #154.