### PR TITLE
Fix build for Python 3 on OS X

### DIFF
--- a/src/vmprof_common.c
+++ b/src/vmprof_common.c
@@ -165,17 +165,6 @@ int opened_profile(const char *interp_name, int memory, int proflines, int nativ
 }
 
 
-/* Seems that CPython 3.5.1 made our job harder.  Did not find out how
-   to do that without these hacks.  We can't use PyThreadState_GET(),
-   because that calls PyThreadState_Get() which fails an assert if the
-   result is NULL. */
-#if PY_MAJOR_VERSION >= 3 && !defined(_Py_atomic_load_relaxed)
-                             /* this was abruptly un-defined in 3.5.1 */
-void *volatile _PyThreadState_Current;
-   /* XXX simple volatile access is assumed atomic */
-#  define _Py_atomic_load_relaxed(pp)  (*(pp))
-#endif
-
 #ifdef RPYTHON_VMPROF
 #ifndef RPYTHON_LL2CTYPES
 PY_STACK_FRAME_T *get_vmprof_stack(void)

--- a/src/vmprof_common.h
+++ b/src/vmprof_common.h
@@ -83,17 +83,6 @@ char *vmprof_init(int fd, double interval, int memory,
 
 int opened_profile(const char *interp_name, int memory, int proflines, int native, int real_time);
 
-/* Seems that CPython 3.5.1 made our job harder.  Did not find out how
-   to do that without these hacks.  We can't use PyThreadState_GET(),
-   because that calls PyThreadState_Get() which fails an assert if the
-   result is NULL. */
-#if PY_MAJOR_VERSION >= 3 && !defined(_Py_atomic_load_relaxed)
-                             /* this was abruptly un-defined in 3.5.1 */
-void *volatile _PyThreadState_Current;
-   /* XXX simple volatile access is assumed atomic */
-#  define _Py_atomic_load_relaxed(pp)  (*(pp))
-#endif
-
 #ifdef RPYTHON_VMPROF
 #ifndef RPYTHON_LL2CTYPES
 PY_STACK_FRAME_T *get_vmprof_stack(void);

--- a/src/vmprof_win.c
+++ b/src/vmprof_win.c
@@ -104,6 +104,17 @@ int vmprof_snapshot_thread(DWORD thread_id, PY_WIN_THREAD_STATE *tstate, prof_st
 #endif
 }
 
+/* Seems that CPython 3.5.1 made our job harder.  Did not find out how
+   to do that without these hacks.  We can't use PyThreadState_GET(),
+   because that calls PyThreadState_Get() which fails an assert if the
+   result is NULL. */
+#if PY_MAJOR_VERSION >= 3 && !defined(_Py_atomic_load_relaxed)
+                             /* this was abruptly un-defined in 3.5.1 */
+void *volatile _PyThreadState_Current;
+   /* XXX simple volatile access is assumed atomic */
+#  define _Py_atomic_load_relaxed(pp)  (*(pp))
+#endif
+
 #ifndef RPYTHON_VMPROF
 static
 PY_WIN_THREAD_STATE * get_current_thread_state(void)


### PR DESCRIPTION
vmprof_common.h gets included on OS X, resulting in multiple definitions of `_PyThreadState_Current`. This definition is only needed in `vmprof_win.c`, so move it there.

I pip installed and ran pytest on the platforms I have available (OS X and Linux). Unfortunately, I don't have access to a Windows machine to test it.

Fixes #197 and #189