### PR TITLE
Fix real_time test for Python 2

### DIFF
--- a/src/vmprof_unix.c
+++ b/src/vmprof_unix.c
@@ -244,11 +244,7 @@ void sigprof_handler(int sig_nr, siginfo_t* info, void *ucontext)
             if (commit) {
                 commit_buffer(fd, p);
             } else {
-#ifndef RPYTHON_VMPROF
                 fprintf(stderr, "WARNING: canceled buffer, no stack trace was written\n");
-#else
-                fprintf(stderr, "WARNING: canceled buffer, no stack trace was written\n");
-#endif
                 cancel_buffer(p);
             }
         }

--- a/vmprof/test/test_run.py
+++ b/vmprof/test/test_run.py
@@ -81,13 +81,22 @@ def function_bar():
 def functime_foo(t=0.05, insert=False):
     if (insert):
         vmprof.insert_real_time_thread()
-    return time.sleep(t)
+    sleep_retry_eintr(t)
 
 
 def functime_bar(t=0.05, remove=False):
     if (remove):
         vmprof.remove_real_time_thread()
-    return time.sleep(t)
+    sleep_retry_eintr(t)
+
+
+def sleep_retry_eintr(t):
+    start = time.time()
+    remaining = t
+    while remaining > 0:
+        time.sleep(remaining)
+        elapsed = time.time() - start
+        remaining = t - elapsed
 
 
 foo_full_name = "py:function_foo:%d:%s" % (function_foo.__code__.co_firstlineno,
@@ -255,7 +264,6 @@ def test_vmprof_real_time():
     assert d[foo_time_name] > 0
 
 
-@py.test.mark.xfail()
 @py.test.mark.skipif("'__pypy__' in sys.builtin_module_names")
 @py.test.mark.skipif("sys.platform == 'win32'")
 @py.test.mark.parametrize("insert_foo,remove_bar", [


### PR DESCRIPTION
On CPython < 3.5, system calls may be interrupted with EINTR when a signal is received (see [PEP-475](https://www.python.org/dev/peps/pep-0475/)). In particular, `sleep` is not retried after SIGALRM, even if requested with `SA_RESTART` (see: [`signal(7)`](http://man7.org/linux/man-pages/man7/signal.7.html)).

This updates and re-enables the `test_vmprof_real_time` test by retrying (if necessary) until the requested time has elapsed. A proper solution for #159 on Python 2 would require a more significant update to not use `SIGALRM`, and having the tests re-enabled first seemed like a good start.

Ref #159 and #202.