### PR TITLE
Broadcast SIGPROF, rather than SIGALRM, when doing real time profiling

### DIFF
--- a/src/vmprof_common.c
+++ b/src/vmprof_common.c
@@ -281,20 +281,16 @@ ssize_t remove_threads(void)
 
 int broadcast_signal_for_threads(void)
 {
-    int done = 1;
     size_t i = 0;
-    pthread_t self = pthread_self();
     pthread_t tid;
     while (i < thread_count) {
         tid = threads[i];
-        if (pthread_equal(tid, self)) {
-            done = 0;
-        } else if (pthread_kill(tid, SIGALRM)) {
+        if (pthread_kill(tid, SIGPROF)) {
             remove_thread(tid, i);
         }
         i++;
     }
-    return done;
+    return 0;
 }
 
 int is_main_thread(void)

--- a/src/vmprof_unix.h
+++ b/src/vmprof_unix.h
@@ -53,6 +53,7 @@ int get_stack_trace(PY_THREAD_STATE_T * current, void** result, int max_depth, i
 void segfault_handler(int arg);
 int _vmprof_sample_stack(struct profbuf_s *p, PY_THREAD_STATE_T * tstate, ucontext_t * uc);
 void sigprof_handler(int sig_nr, siginfo_t* info, void *ucontext);
+void sigalrm_handler(int sig_nr, siginfo_t* info, void *ucontext);
 
 
 /* *************************************************************
@@ -60,10 +61,13 @@ void sigprof_handler(int sig_nr, siginfo_t* info, void *ucontext);
  * *************************************************************
  */
 
+
 int install_sigprof_handler(void);
 int remove_sigprof_handler(void);
-int install_sigprof_timer(void);
-int remove_sigprof_timer(void);
+int install_sigalrm_handler(void);
+int remove_sigalrm_handler(void);
+int install_timer(void);
+int remove_timer(void);
 void atfork_disable_timer(void);
 void atfork_enable_timer(void);
 void atfork_close_profile_file(void);

--- a/vmprof/test/test_run.py
+++ b/vmprof/test/test_run.py
@@ -255,7 +255,6 @@ def test_vmprof_real_time():
     assert d[foo_time_name] > 0
 
 
-@py.test.mark.xfail()
 @py.test.mark.skipif("'__pypy__' in sys.builtin_module_names")
 @py.test.mark.skipif("sys.platform == 'win32'")
 @py.test.mark.parametrize("insert_foo,remove_bar", [


### PR DESCRIPTION
Real-time profiling uses a signal broadcast mechanism to capture all registered threads, since the `SIGALRM` delivered by `ITIMER_REAL` is only sent to the main thread.

This change updates the broadcasting logic to send `SIGPROF` to trigger the actual stack sampling handler, rather than `SIGALRM`. This separates the logic for handling the broadcast (SIGALRM handler) from handling the stack collection (always SIGPROF handler). It also helps mitigate #159, since the threads will be receiving `SIGPROF` rather than `SIGALRM`, which disrupts time.sleep (It is not a perfect fix because the main thread may still be disrupted, but this seems to be a limitation of setitimer). This also fixes the real_time_threaded test, which is currently marked xfail.

Ref #153 and #204.