### PR TITLE
Guard fprintf behind DEBUG since they are not guaranteed to be signal safe

### DIFF
--- a/src/vmp_stack.c
+++ b/src/vmp_stack.c
@@ -189,14 +189,18 @@ int vmp_walk_and_record_stack(PY_STACK_FRAME_T *frame, void ** result,
     ret = unw_getcontext(&uc);
     if (ret < 0) {
         // could not initialize lib unwind cursor and context
+#if DEBUG
         fprintf(stderr, "WARNING: unw_getcontext did not retreive context, switching to python profiling mode \n");
+#endif
         vmp_native_disable();
         return vmp_walk_and_record_python_stack_only(frame, result, max_depth, 0, pc);
     }
     ret = unw_init_local(&cursor, &uc);
     if (ret < 0) {
         // could not initialize lib unwind cursor and context
+#if DEBUG
         fprintf(stderr, "WARNING: unw_init_local did not succeed, switching to python profiling mode \n");
+#endif
         vmp_native_disable();
         return vmp_walk_and_record_python_stack_only(frame, result, max_depth, 0, pc);
     }
@@ -205,7 +209,9 @@ int vmp_walk_and_record_stack(PY_STACK_FRAME_T *frame, void ** result,
         while (signal < 0) {
             int err = unw_step(&cursor);
             if (err <= 0) {
+#if DEBUG
                 fprintf(stderr, "WARNING: did not find signal frame, skipping sample\n");
+#endif
                 return 0;
             }
             signal++;
@@ -220,7 +226,9 @@ int vmp_walk_and_record_stack(PY_STACK_FRAME_T *frame, void ** result,
             }
             int err = unw_step(&cursor);
             if (err <= 0) {
+#if DEBUG
                 fprintf(stderr,"WARNING: did not find signal frame, skipping sample\n");
+#endif
                 return 0;
             }
         }
@@ -577,7 +585,9 @@ void vmp_native_disable(void) {
     if (libhandle != NULL) {
         if (dlclose(libhandle)) {
             vmprof_error = dlerror();
+#if DEBUG
             fprintf(stderr, "could not close libunwind at runtime. error: %s\n", vmprof_error);
+#endif
         }
         libhandle = NULL;
     }

--- a/src/vmprof_unix.c
+++ b/src/vmprof_unix.c
@@ -127,7 +127,9 @@ PY_THREAD_STATE_T * _get_pystate_for_this_thread(void) {
     mythread_id = PyThread_get_thread_ident();
     istate = PyInterpreterState_Head();
     if (istate == NULL) {
+#if DEBUG
         fprintf(stderr, "WARNING: interp state head is null (for thread id %ld)\n", mythread_id);
+#endif
         return NULL;
     }
     // fish fish fish, it will NOT lock the keymutex in pythread
@@ -141,7 +143,9 @@ PY_THREAD_STATE_T * _get_pystate_for_this_thread(void) {
     } while ((istate = PyInterpreterState_Next(istate)) != NULL);
 
     // uh? not found?
+#if DEBUG
     fprintf(stderr, "WARNING: cannot find thread state (for thread id %ld), sample will be thrown away\n", mythread_id);
+#endif
     return NULL;
 }
 #endif
@@ -244,7 +248,9 @@ void sigprof_handler(int sig_nr, siginfo_t* info, void *ucontext)
             if (commit) {
                 commit_buffer(fd, p);
             } else {
+#if DEBUG
                 fprintf(stderr, "WARNING: canceled buffer, no stack trace was written\n");
+#endif
                 cancel_buffer(p);
             }
         }
@@ -477,13 +483,17 @@ int get_stack_trace(PY_THREAD_STATE_T * current, void** result, int max_depth, i
     frame = (PY_STACK_FRAME_T*)current;
 #else
     if (current == NULL) {
+#if DEBUG
         fprintf(stderr, "WARNING: get_stack_trace, current is NULL\n");
+#endif
         return 0;
     }
     frame = current->frame;
 #endif
     if (frame == NULL) {
+#if DEBUG
         fprintf(stderr, "WARNING: get_stack_trace, frame is NULL\n");
+#endif
         return 0;
     }
     return vmp_walk_and_record_stack(frame, result, max_depth, 1, pc);


### PR DESCRIPTION
Fixes #208. TBH I am not sure if is totally necessary on Linux, but since these functions otherwise take great care to be async-signal-safe it seemed prudent. These warning messages can be quite common in my application due to background threads created in C modules (#140).