### PR TITLE
Fix: sizeof(pid_t) != sizeof(pthread_t)

### DIFF
--- a/src/vmprof_common.c
+++ b/src/vmprof_common.c
@@ -244,9 +244,9 @@ ssize_t insert_thread(pthread_t tid, ssize_t i)
         return -1;
     if (thread_count == threads_size) {
         threads_size += threads_size_step;
-        threads = realloc(threads, sizeof(pid_t) * threads_size);
+        threads = realloc(threads, sizeof(pthread_t) * threads_size);
         assert(threads != NULL);
-        memset(threads + thread_count, 0, sizeof(pid_t) * threads_size_step);
+        memset(threads + thread_count, 0, sizeof(pthread_t) * threads_size_step);
     }
     threads[thread_count++] = tid;
     return thread_count;


### PR DESCRIPTION
The real-time profiling code manages [an array of threads to profile](https://github.com/vmprof/vmprof-python/blob/master/src/vmprof_common.c#L34-L37). This array is an array of `pthread_t` identifiers, but the code to allocate the array uses `sizeof(pid_t)`, which many not equal `sizeof(pthread_t)`. In particular, on Linux 4.15 x86_64, `sizeof(pthread_t) = 8` while `sizeof(pid_t) = 4`. This leads to crashes since the code will write beyond its allocated space.

Based on git history, I believe this has existed since the introduction of `real_time` support in https://github.com/vmprof/vmprof-python/commit/ccae9f7d9148634fd3366e504e97deb4b7e29eb7.

Fixes #210.