### PR TITLE
docs: fix simple typo, unkown -> unknown

### DIFF
--- a/vmprof/stats.py
+++ b/vmprof/stats.py
@@ -15,7 +15,7 @@ class Stats(object):
             self.profile_lines = state.profile_lines
             self.profile_memory = state.profile_memory
         else:
-            # unkown, for tests only
+            # unknown, for tests only
             self.profile_lines = False
             self.profile_memory = False
         self.generate_top()


### PR DESCRIPTION
There is a small typo in vmprof/stats.py.

Should read `unknown` rather than `unkown`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md