### PR TITLE
Add a 'flat' profile mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Line #     Hits   % Hits  Line Contents
 ```
 
 ### "Flattened" output
+`vmprofshow` also has a `flat` mode.
 
 While the tree-based and line-based output styles for `vmprofshow` give a good
 view of where time is spent when viewed from the 'root' of the call graph,

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ On Windows this means you need Microsoft Visual C++ Compiler for your Python ver
 
 Setting up development can be done using the following commands:
 
-        $ virtualenv -p /usr/bin/python3 vmprof3
-        $ source vmprof3/bin/activate
-        $ python setup.py develop
+    $ virtualenv -p /usr/bin/python3 vmprof3
+    $ source vmprof3/bin/activate
+    $ python setup.py develop
 
 You need to install python development packages. In case of e.g. Debian or Ubuntu the package you need is `python3-dev` and `libunwind-dev`.
 Now it is time to write a test and implement your feature. If you want

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ On Windows this means you need Microsoft Visual C++ Compiler for your Python ver
 
 Setting up development can be done using the following commands:
 
-	$ virtualenv -p /usr/bin/python3 vmprof3
-	$ source vmprof3/bin/activate
-	$ python setup.py develop
+        $ virtualenv -p /usr/bin/python3 vmprof3
+        $ source vmprof3/bin/activate
+        $ python setup.py develop
 
 You need to install python development packages. In case of e.g. Debian or Ubuntu the package you need is `python3-dev` and `libunwind-dev`.
 Now it is time to write a test and implement your feature. If you want
@@ -45,20 +45,23 @@ Here is an example of how to use `vmprofshow`:
 Run that smallish program which burns CPU cycles (with vmprof enabled):
 
 ```console
-pypy vmprof/test/cpuburn.py # you can find cpuburn.py in the vmprof-python repo
+$ pypy vmprof/test/cpuburn.py # you can find cpuburn.py in the vmprof-python repo
 ```
 
 This will produce a profile file `vmprof_cpuburn.dat`.
-Now display the profile:
+Now display the profile using `vmprofshow`. `vmprofshow` has multiple modes
+of showing data. We'll start with the tree-based mode.
+
+### Tree-based output
 
 ```console
-vmprofshow vmprof_cpuburn.dat
+$ vmprofshow vmprof_cpuburn.dat tree
 ```
 
 You will see a (colored) output:
 
 ```console
-oberstet@thinkpad-t430s:~/scm/vmprof-python$ vmprofshow vmprof_cpuburn.dat
+$ vmprofshow vmprof_cpuburn.dat tree
 100.0%  <module>  100.0%  tests/cpuburn.py:1
 100.0% .. test  100.0%  tests/cpuburn.py:35
 100.0% .... burn  100.0%  tests/cpuburn.py:26
@@ -73,7 +76,7 @@ oberstet@thinkpad-t430s:~/scm/vmprof-python$ vmprofshow vmprof_cpuburn.dat
 ```
 
 
-## Line profiling
+### Line-based output
 
 vmprof supports line profiling mode, which enables collecting and showing the statistics for separate lines
 inside functions.
@@ -81,24 +84,24 @@ inside functions.
 To enable collection of lines statistics add `--lines` argument to vmprof:
 
 ```console
-python -m vmprof --lines -o <output-file> <your program> <your program args>
+$ python -m vmprof --lines -o <output-file> <your program> <your program args>
 ```
 
 Or pass `lines=True` argument to `vmprof.enable` function, when calling vmprof from code.
 
 To see line statistics for all functions add the `--lines` argument to `vmprofshow`:
 ```console
-vmprofshow --lines <output-file>
+$ vmprofshow <output-file> lines
 ```
 
 To see line statistics for a specific function use the `--filter` argument with the function name:
 ```console
-vmprofshow --lines --filter <function-name> <output-file>
+$ vmprofshow <output-file> lines --filter <function-name>
 ```
 
 You will see the result:
 ```console
-macbook-pro-4:vmprof-python traff$ vmprofshow --lines --filter _next_rand vmprof_cpuburn.dat
+$ vmprofshow vmprof_cpuburn.dat lines --filter _next_rand
 Total hits: 1170 s
 File: tests/cpuburn.py
 Function: _next_rand at line 14
@@ -111,3 +114,63 @@ Line #     Hits   % Hits  Line Contents
     17      297     25.4          return self._rand
 ```
 
+### "Flattened" output
+
+While the tree-based and line-based output styles for `vmprofshow` give a good
+view of where time is spent when viewed from the 'root' of the call graph,
+sometimes it is desirable to get a view from 'leaves' instead. This is particularly
+helpful when functions exist that get called from multiple places, where each
+invocation does not consume much time, but all invocations taken together do
+amount to a substantial cost.
+```console
+$ vmprofshow vmprof_cpuburn.dat flat                                                                                                                                                                                                                                                                                                                                                                                   andreask_work@dunkel 15:24
+    28.895% - _PyFunction_Vectorcall:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/call.c:389
+    18.076% - _iterate:cpuburn.py:20
+    17.298% - _next_rand:cpuburn.py:15
+     5.863% - <native symbol 0x563a5f4eea51>:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/longobject.c:3707
+     5.831% - PyObject_SetAttr:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/object.c:1031
+     4.924% - <native symbol 0x563a5f43fc01>:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/abstract.c:787
+     4.762% - PyObject_GetAttr:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/object.c:931
+     4.373% - <native symbol 0x563a5f457eb1>:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/abstract.c:1071
+     3.758% - PyNumber_Add:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/abstract.c:957
+     3.110% - <native symbol 0x563a5f47c291>:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/longobject.c:4848
+     1.587% - PyNumber_Multiply:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/abstract.c:988
+     1.166% - _PyObject_GetMethod:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/object.c:1139
+     0.356% - <native symbol 0x563a5f4ed8f1>:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/longobject.c:3432
+     0.000% - <native symbol 0x7f0dce8cca80>:-:0
+     0.000% - test:cpuburn.py:36
+     0.000% - burn:cpuburn.py:27
+```
+Sometimes it may be desirable to exclude "native" functions:
+```console
+$ vmprofshow vmprof_cpuburn.dat flat --no-native                                                                                                                                                                                                                                                                                                                                                                       andreask_work@dunkel 15:27
+    53.191% - _next_rand:cpuburn.py:15
+    46.809% - _iterate:cpuburn.py:20
+     0.000% - test:cpuburn.py:36
+     0.000% - burn:cpuburn.py:27
+```
+Note that the output represents the time spent in each function, *exclusive* of
+functions called. (In `--no-native` mode, native-code callees remain included
+in the total.)
+
+Sometimes it may also be desirable to get timings *inclusive* of called functions:
+```
+vmprofshow vmprof_cpuburn.dat flat --include-callees                                                                                                                                                                                                                                                                                                                                                                 andreask_work@dunkel 15:31
+   100.000% - <native symbol 0x7f0dce8cca80>:-:0
+   100.000% - test:cpuburn.py:36
+   100.000% - burn:cpuburn.py:27
+   100.000% - _iterate:cpuburn.py:20
+    53.191% - _next_rand:cpuburn.py:15
+    28.895% - _PyFunction_Vectorcall:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/call.c:389
+     7.807% - PyNumber_Multiply:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/abstract.c:988
+     7.483% - <native symbol 0x563a5f457eb1>:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/abstract.c:1071
+     6.220% - <native symbol 0x563a5f4eea51>:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/longobject.c:3707
+     5.831% - PyObject_SetAttr:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/object.c:1031
+     4.924% - <native symbol 0x563a5f43fc01>:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/abstract.c:787
+     4.762% - PyObject_GetAttr:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/object.c:931
+     3.758% - PyNumber_Add:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/abstract.c:957
+     3.110% - <native symbol 0x563a5f47c291>:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/longobject.c:4848
+     1.166% - _PyObject_GetMethod:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/object.c:1139
+     0.356% - <native symbol 0x563a5f4ed8f1>:/home/conda/feedstock_root/build_artifacts/python-split_1608956461873/work/Objects/longobject.c:3432
+```
+This view is quite similar to the "tree" view, minus the nesting.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ in the total.)
 
 Sometimes it may also be desirable to get timings *inclusive* of called functions:
 ```
-vmprofshow vmprof_cpuburn.dat flat --include-callees                                                                                                                                                                                                                                                                                                                                                                 andreask_work@dunkel 15:31
+$ vmprofshow vmprof_cpuburn.dat flat --include-callees                                                                                                                                                                                                                                                                                                                                                                 andreask_work@dunkel 15:31
    100.000% - <native symbol 0x7f0dce8cca80>:-:0
    100.000% - test:cpuburn.py:36
    100.000% - burn:cpuburn.py:27

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ python -m vmprof --lines -o <output-file> <your program> <your program args>
 
 Or pass `lines=True` argument to `vmprof.enable` function, when calling vmprof from code.
 
-To see line statistics for all functions add the `--lines` argument to `vmprofshow`:
+To see line statistics for all functions use the  `lines` mode of `vmprofshow`:
 ```console
 $ vmprofshow <output-file> lines
 ```

--- a/vmprof/show.py
+++ b/vmprof/show.py
@@ -202,7 +202,7 @@ class FlatPrinter(AbstractPrinter):
                 print(
                         f'{percent:10.3f} - '
                         f'{ndescr.block_type}:{ndescr.funname}:'
-                        f'{ndescr.funline}:{ndescr.filename}')
+                        f'{ndescr.filename}:{ndescr.funline}')
 
 
 class LinesPrinter(AbstractPrinter):

--- a/vmprof/show.py
+++ b/vmprof/show.py
@@ -201,7 +201,7 @@ class FlatPrinter(AbstractPrinter):
             if percent >= self.percent_cutoff:
                 print(
                         f'{percent:10.3f} - '
-                        f'{ndescr.block_type}:{ndescr.funname}:'
+                        f'{color(ndescr.funname, color.WHITE, bold=True)}:'
                         f'{ndescr.filename}:{ndescr.funline}')
 
 

--- a/vmprof/show.py
+++ b/vmprof/show.py
@@ -203,9 +203,12 @@ class FlatPrinter(AbstractPrinter):
 
             if percent >= self.percent_cutoff:
                 print(
-                        f'{percent:10.3f}% - '
-                        f'{color(ndescr.funname, color.WHITE, bold=True)}:'
-                        f'{ndescr.filename}:{ndescr.funline}')
+                        '{percent:10.3f}% - {funcname}:{filename}:{funline}'
+                        .format(
+                            percent=percent,
+                            funcname=color(ndescr.funname, color.WHITE, bold=True),
+                            filename=ndescr.filename,
+                            funline=ndescr.funline))
 
 
 class LinesPrinter(AbstractPrinter):

--- a/vmprof/show.py
+++ b/vmprof/show.py
@@ -200,7 +200,7 @@ class FlatPrinter(AbstractPrinter):
 
             if percent >= self.percent_cutoff:
                 print(
-                        f'{percent:10.3f} - '
+                        f'{percent:10.3f}% - '
                         f'{color(ndescr.funname, color.WHITE, bold=True)}:'
                         f'{ndescr.filename}:{ndescr.funline}')
 

--- a/vmprof/show.py
+++ b/vmprof/show.py
@@ -8,6 +8,7 @@ import sys
 import tokenize
 import vmprof
 import argparse
+from collections import namedtuple
 
 from vmprof.stats import EmptyProfileFile
 
@@ -91,8 +92,6 @@ class PrettyPrinter(AbstractPrinter):
             level_indent = ""
 
         def print_node(parent, node, level):
-            parent_name = parent.name if parent else None
-
             perc = round(100. * float(node.count) / total, 1)
             if parent and parent.count:
                 perc_of_parent = round(100. * float(node.count) / float(parent.count), 1)
@@ -131,6 +130,79 @@ class PrettyPrinter(AbstractPrinter):
                 print("{} {} {}  {}  {}".format(p1, p2b, p2, p4, p3))
 
         self._walk_tree(None, tree, 0, print_node)
+
+
+NodeDescr = namedtuple(
+        'NodeDescr',
+        ['block_type', 'funname', 'funline', 'filename'])
+
+
+def parse_block_name(node_name):
+    nparts = node_name.count(':')+1
+
+    block_type = None
+    funline = None
+    filename = None
+    if nparts == 4:
+        block_type, funname, funline, filename = node_name.split(':')
+    elif nparts == 2:
+        block_type, funname = node_name.split(':')
+    else:
+        funname = node_name
+
+    return NodeDescr(block_type, funname, funline, filename)
+
+
+class FlatPrinter(AbstractPrinter):
+    """
+    A per-function pretty-printer of vmprof profiles.
+    """
+
+    def __init__(self, no_native, percent_cutoff):
+        self.no_native = no_native
+        self.percent_cutoff = percent_cutoff
+
+    def _show(self, tree):
+        self._print_tree(tree)
+
+    def _walk_tree(self, parent, node, callback):
+        callback(parent, node)
+        for c in six.itervalues(node.children):
+            self._walk_tree(node, c, callback)
+
+    def _print_tree(self, tree):
+        func_id_to_count = {}
+
+        def collect_node(parent, node):
+            ndescr = parse_block_name(node.name)
+            if self.no_native and ndescr.block_type == 'n':
+                return
+
+            mycount = node.count - sum(
+                    0 if parse_block_name(ch.name)[0] == 'n' and self.no_native
+                    else ch.count
+
+                    for ch in six.itervalues(node.children))
+
+            func_id_to_count[ndescr] = func_id_to_count.get(ndescr, 0) + mycount
+
+        self._walk_tree(None, tree, collect_node)
+
+        cost_list = sorted(
+                func_id_to_count.items(),
+                key=(lambda item: item[1]),
+                reverse=True)
+
+        total = float(tree.count)
+
+        for ndescr, count in cost_list:
+            percent = count/total*100
+
+            if percent >= self.percent_cutoff:
+                print(
+                        f'{percent:10.3f} - '
+                        f'{ndescr.block_type}:{ndescr.funname}:'
+                        f'{ndescr.funline}:{ndescr.filename}')
 
 
 class LinesPrinter(AbstractPrinter):
@@ -232,42 +304,59 @@ class LinesPrinter(AbstractPrinter):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("profile")
+    subp = parser.add_subparsers()
 
-    parser.add_argument(
+    parser_tree = subp.add_parser("tree")
+    parser_tree.add_argument(
         '--prune_percent',
         type=float,
         default=0,
         help="Prune output of a profile stats node below specified CPU samples.")
-
-    parser.add_argument(
+    parser_tree.add_argument(
         '--prune_level',
         type=int,
         default=None,
         help='Prune output of a profile stats node below specified depth.')
-
-    parser.add_argument(
+    parser_tree.add_argument(
         '--indent',
         type=int,
         default=2,
         help='The indention per level within the call graph.')
+    parser_tree.set_defaults(mode='tree')
 
-    parser.add_argument('--lines', dest='lines', action='store_true')
-    parser.set_defaults(lines=False)
-
-    parser.add_argument('--filter', dest='filter', type=str,
+    parser_lines = subp.add_parser("lines")
+    parser_lines.add_argument('--filter', dest='filter', type=str,
                         default=None, help="Filters the console output when "
                         "vmprofshow is invoked with --lines. Filters by "
                         "function names or filenames.")
+    parser_lines.set_defaults(mode='lines')
+
+    parser_flat = subp.add_parser("flat")
+    parser_flat.add_argument('--no-native', action="store_true")
+    parser_flat.add_argument('--percent-cutoff', type=float, default=0)
+    parser_flat.set_defaults(mode='flat')
 
     args = parser.parse_args()
 
-    if args.lines:
+    mode = getattr(args, 'mode', None)
+    if mode is None:
+        parser. print_usage()
+        import sys
+        sys.exit(1)
+
+    if mode == 'lines':
         pp = LinesPrinter(filter=args.filter)
-    else:
+    elif mode == 'flat':
+        pp = FlatPrinter(
+                no_native=args.no_native,
+                percent_cutoff=args.percent_cutoff)
+    elif mode == 'tree':
         pp = PrettyPrinter(
             prune_percent=args.prune_percent,
             prune_level=args.prune_level,
             indent=args.indent)
+    else:
+        raise ValueError("invalid value for 'mode'")
 
     pp.show(args.profile)
 

--- a/vmprof/test/cpuburn.py
+++ b/vmprof/test/cpuburn.py
@@ -58,4 +58,4 @@ if __name__ == '__main__':
     vmprof.disable()
 
     print("\nProfile written to {}.".format(PROFILE_FILE))
-    print("To view the profile, run: vmprofshow {}".format(PROFILE_FILE))
+    print("To view the profile, run: vmprofshow {} tree".format(PROFILE_FILE))


### PR DESCRIPTION
While the default display of vmprof is very successful at finding where code spends its time viewed from the root of the call tree, it does not work well to find the worst offenders when viewed from the leaves, i.e. functions that spend a lot of time in aggregate, by being called very often. This PR refactors `vmprofshow` to use `ArgumentParser` subparsers for its command line interface, and makes the existing `lines` mode use that. It also adds a `flat` mode that presents `flat` statistics of time used, a bit more like `pstats` from `cProfile`. Here's some example output:
```
     5.585 - py:__init__:431:/shared/home/andreask_work/pack/emirge/pyopencl/pyopencl/array.py
     5.230 - py:enqueue_knl_axpbyz:4:<generated code>
     5.098 - py:kernel_runner:148:/shared/home/andreask_work/pack/emirge/pyopencl/pyopencl/array.py
     4.566 - py:_lpy_host_resample_by_picking:8:<generated code>
     4.433 - py:wrapper:675:/home/andreask_work/shared/pack/emirge/miniforge3/envs/ceesd/lib/python3.8/site-packages/pytools/__init__.py
     4.388 - py:enqueue_knl_axpb:4:<generated code>
     4.034 - py:call_loopy:483:/shared/home/andreask_work/pack/emirge/meshmode/meshmode/array_context.py
     3.812 - py:get_common_dtype:79:/shared/home/andreask_work/pack/emirge/pyopencl/pyopencl/compyte/array.py
     3.812 - py:enqueue_knl_multiply:4:<generated code>
     2.128 - py:_lpy_host_diff:8:<generated code>
     2.039 - py:product:1055:/home/andreask_work/shared/pack/emirge/miniforge3/envs/ceesd/lib/python3.8/site-packages/pytools/__init__.py
     1.773 - py:_bop:242:/shared/home/andreask_work/pack/emirge/meshmode/meshmode/dof_array.py
     1.729 - py:invoke_resample_by_picking_loopy_kernel:118:<generated code>
```
A legitimate question would be, why add that when `cProfile` already has that. I'll simply add the (analogous) cProfile output fo the same code:
```
    65500    1.328    0.000    1.328    0.000 {built-in method pyopencl._cl.enqueue_nd_range_kernel}
    40300    0.620    0.000    3.918    0.000 /shared/home/andreask_work/pack/emirge/pyopencl/pyopencl/array.py:148(kernel_runner)
    60300    0.569    0.000    0.815    0.000 /shared/home/andreask_work/pack/emirge/pyopencl/pyopencl/array.py:431(__init__)
    25200    0.388    0.000    2.603    0.000 /shared/home/andreask_work/pack/emirge/meshmode/meshmode/array_context.py:483(call_loopy)
321000/295800    0.351    0.000    1.695    0.000 /home/andreask_work/shared/pack/emirge/miniforge3/envs/ceesd/lib/python3.8/site-packages/pytools/__init__.py:675(wrapper)
    39900    0.241    0.000    0.400    0.000 /shared/home/andreask_work/pack/emirge/pyopencl/pyopencl/compyte/array.py:79(get_common_dtype)
  1189900    0.236    0.000    0.270    0.000 {built-in method builtins.isinstance}
   783800    0.208    0.000    0.208    0.000 {built-in method builtins.getattr}
    12000    0.181    0.000    0.469    0.000 <generated code>:8(_lpy_host_resample_by_picking)
    77600    0.180    0.000    0.180    0.000 {built-in method numpy.zeros}
    13700    0.173    0.000    0.500    0.000 <generated code>:4(enqueue_knl_axpbyz)
```
Note that the two sets of output are nothing alike... and at least for now I'm inclined to trust vmprof more. :)

At any rate, thanks for vmprof, and maybe you'll find this useful.

cc @matthiasdiener