### PR TITLE
Use |... for indentation in vmprofshow

### DIFF
--- a/vmprof/show.py
+++ b/vmprof/show.py
@@ -66,7 +66,7 @@ class PrettyPrinter(AbstractPrinter):
         """
         assert(prune_percent is None or (prune_percent >= 0 and prune_percent <= 100))
         assert(prune_level is None or (prune_level >= 0 and prune_level <= 1000))
-        assert(indent is None or (indent >= 0 and indent <= 4))
+        assert(indent is None or (indent >= 0 and indent <= 8))
         self._prune_percent = prune_percent or 0.
         self._prune_level = prune_level or 1000
         self._indent = indent or 2
@@ -85,6 +85,11 @@ class PrettyPrinter(AbstractPrinter):
     def _print_tree(self, tree):
         total = float(tree.count)
 
+        if self._indent:
+            level_indent = "|" + "." * (self._indent-1)
+        else:
+            level_indent = ""
+
         def print_node(parent, node, level):
             parent_name = parent.name if parent else None
 
@@ -101,7 +106,7 @@ class PrettyPrinter(AbstractPrinter):
                     block_type, funname, funline, filename = node.name.split(':')
 
                     p2 = color(funname, color.BLUE, bold=True)
-                    p2b = color(('.' * level * self._indent), color.BLUE)
+                    p2b = color(level_indent * level, color.BLUE)
 
                     p3 = []
                     if os.path.dirname(filename):
@@ -113,11 +118,11 @@ class PrettyPrinter(AbstractPrinter):
                 elif parts == 1:
                     block_type, funname = node.name.split(':')
                     p2 = color("JIT code", color.RED, bold=True)
-                    p2b = color('.' * level * self._indent, color.RED, bold=False)
+                    p2b = color(level_indent * level, color.RED, bold=False)
                     p3 = color(funname, color.WHITE, bold=False)
                 else:
                     p2 = color(node.name, color.WHITE)
-                    p2b = color(('.' * level * self._indent), color.WHITE)
+                    p2b = color(level_indent * level, color.WHITE)
                     p3 = "<unknown>"
 
                 p1 = color("{:>5}%".format(perc), color.WHITE, bold=True)


### PR DESCRIPTION
This makes indentation levels easier to pick apart, compared to the default. After

```
100.0%  <native symbol 0x7f06eec5fc90>  100.0%  -:0
 99.9% |... main  99.9%  wave-eager.py:61
 99.9% |...|... f  100.0%  wave-eager.py:113
 99.9% |...|...|... rk4_step  100.0%  /shared/home/andreask_work/pack/emirge/mirgecom/mirgecom/integrators.py:38
 94.8% |...|...|...|... rhs  94.9%  wave-eager.py:104
 94.8% |...|...|...|...|... wave_operator  100.0%  /shared/home/andreask_work/pack/emirge/mirgecom/mirgecom/wave.py:61
  9.7% |...|...|...|...|...|... interior_trace_pair  10.2%  /shared/home/andreask_work/pack/emirge/grudge/grudge/eager.py:368
  5.3% |...|...|...|...|...|...|... project  54.4%  /shared/home/andreask_work/pack/emirge/grudge/grudge/eager.py:78
  5.3% |...|...|...|...|...|...|...|... obj_array_vectorize  100.0%  /home/andreask_work/shared/pack/emirge/miniforge3/envs/ceesd/lib/python3.8/site-packages/pytools/obj_array.py:124
  4.9% |...|...|...|...|...|...|...|...|... <lambda>  92.9%  /shared/home/andreask_work/pack/emirge/grudge/grudge/eager.py:94
  4.9% |...|...|...|...|...|...|...|...|...|... project  100.0%  /shared/home/andreask_work/pack/emirge/grudge/grudge/eager.py:78
  4.9% |...|...|...|...|...|...|...|...|...|...|... __call__  100.0%  <decorator-gen-52>:1
  4.9% |...|...|...|...|...|...|...|...|...|...|...|... obj_array_vectorize_n_args  100.0%  /home/andreask_work/shared/pack/emirge/miniforge3/envs/ceesd/lib/python3.8/site-packages/pytools/obj_array.py:174
  4.8% |...|...|...|...|...|...|...|...|...|...|...|...|... __call__  98.1%  /shared/home/andreask_work/pack/emirge/meshmode/meshmode/discretization/connection/direct.py:253
  3.9% |...|...|...|...|...|...|...|...|...|...|...|...|...|... call_loopy  82.4%  /shared/home/andreask_work/pack/emirge/meshmode/meshmode/array_context.py:483
```
Before:
```
100.0%  <native symbol 0x7f06eec5fc90>  100.0%  -:0
 99.9% .... main  99.9%  wave-eager.py:61
 99.9% ........ f  100.0%  wave-eager.py:113
 99.9% ............ rk4_step  100.0%  /shared/home/andreask_work/pack/emirge/mirgecom/mirgecom/integrators.py:38
 94.8% ................ rhs  94.9%  wave-eager.py:104
 94.8% .................... wave_operator  100.0%  /shared/home/andreask_work/pack/emirge/mirgecom/mirgecom/wave.py:61
  9.7% ........................ interior_trace_pair  10.2%  /shared/home/andreask_work/pack/emirge/grudge/grudge/eager.py:368
  5.3% ............................ project  54.4%  /shared/home/andreask_work/pack/emirge/grudge/grudge/eager.py:78
  5.3% ................................ obj_array_vectorize  100.0%  /home/andreask_work/shared/pack/emirge/miniforge3/envs/ceesd/lib/python3.8/site-packages/pytools/obj_array.py:124
  4.9% .................................... <lambda>  92.9%  /shared/home/andreask_work/pack/emirge/grudge/grudge/eager.py:94
  4.9% ........................................ project  100.0%  /shared/home/andreask_work/pack/emirge/grudge/grudge/eager.py:78
  4.9% ............................................ __call__  100.0%  <decorator-gen-52>:1
  4.9% ................................................ obj_array_vectorize_n_args  100.0%  /home/andreask_work/shared/pack/emirge/miniforge3/envs/ceesd/lib/python3.8/site-packages/pytools/obj_array.py:174
```