### PR TITLE
Add option to print tree as HTML with <details>

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ $ vmprofshow vmprof_cpuburn.dat tree
   0.0% ........ JIT code  0.0%  0x7fa7dba583b0
 ```
 
+There is also an option ``--html`` to emit the same information as HTML to view
+in a browser. In this case, the tree branches can be interactively expanded and
+collapsed.
 
 ### Line-based output
 


### PR DESCRIPTION
This adds a very bare-bones HTML output mode to the `tree` subcommand:

![grafik](https://user-images.githubusercontent.com/352067/121964574-5e0e0200-cd31-11eb-8926-6aafb4da4b36.png)

Being able to expand and collapse the branches of the tree is quite handy, and it's not even a lot of extra code. The diff is big mainly because I promoted `_print_node` to its own method. Its content is essentially unchanged.