### PR TITLE
Remove Python 2 support

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,3 @@
-six
 requests
 backports.shutil_which
 pytz

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,3 @@
 requests
-backports.shutil_which
 pytz
 colorama

--- a/jitlog/marks.py
+++ b/jitlog/marks.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from jitlog import constants as const
 from jitlog import merge_point
 from jitlog.objects import FlatOp, MergePoint

--- a/jitlog/merge_point.py
+++ b/jitlog/merge_point.py
@@ -1,7 +1,7 @@
 from jitlog import constants as const
 from vmshare.binary import read_string, read_le_u64
 
-class MergePointDecoder(object):
+class MergePointDecoder:
     def __init__(self, sem_type):
         self.sem_type = sem_type
         self.last_prefix = None

--- a/jitlog/objects.py
+++ b/jitlog/objects.py
@@ -5,7 +5,6 @@ import argparse
 from collections import defaultdict
 from jitlog import constants as const, merge_point
 
-PY3 = sys.version_info[0] >= 3
 
 class FlatOp(object):
     def __init__(self, opnum, opname, args, result,
@@ -53,7 +52,7 @@ class FlatOp(object):
             if timeval < timepos:
                 continue # do not apply the patch
             op_off = self.core_dump[0]
-            patch_start = (addr - base_addr) - op_off 
+            patch_start = (addr - base_addr) - op_off
             patch_end = patch_start + len(content)
             content_end = len(content)-1
             if patch_end >= len(coredump):
@@ -430,8 +429,7 @@ def decode_source(source_bytes):
 def read_python_source(file):
     with open(file, 'rb') as fd:
         data = fd.read()
-        if PY3:
-            data = decode_source(data)
+        data = decode_source(data)
         return data
 
 class TraceForest(object):
@@ -571,8 +569,7 @@ class TraceForest(object):
         for filename, lines in self.source_lines.items():
             marks.append(const.MARK_SOURCE_CODE)
             data = filename
-            if PY3:
-                data = data.encode('utf-8')
+            data = data.encode('utf-8')
             marks.append(struct.pack('<I', len(data)))
             marks.append(data)
 

--- a/jitlog/objects.py
+++ b/jitlog/objects.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from jitlog import constants as const, merge_point
 
 
-class FlatOp(object):
+class FlatOp:
     def __init__(self, opnum, opname, args, result,
                  descr=None, descr_number=None, failargs=None):
         self.opnum = opnum
@@ -114,7 +114,7 @@ class MergePoint(FlatOp):
     def __repr__(self):
         return 'debug_merge_point(xxx)'
 
-class Stage(object):
+class Stage:
     def __init__(self, mark, timeval):
         self.mark = mark
         self.ops = []
@@ -162,7 +162,7 @@ from collections import namedtuple
 class TraceLink(namedtuple('TraceLink', 'origin target')):
     pass
 
-class Trace(object):
+class Trace:
     def __init__(self, forest, trace_type, tick, unique_id, jd_name=None):
         self.forest = forest
         self.jd_name = jd_name
@@ -386,7 +386,7 @@ def iter_ranges(numbers):
             last = i
     yield range(first, last+1)
 
-class PointInTrace(object):
+class PointInTrace:
     def __init__(self, trace, op):
         self.trace = trace
         self.op = op
@@ -432,7 +432,7 @@ def read_python_source(file):
         data = decode_source(data)
         return data
 
-class TraceForest(object):
+class TraceForest:
     def __init__(self, version, is_32bit=False, machine=None):
         self.word_size = 4 if is_32bit else 8
         self.version = version

--- a/jitlog/parser.py
+++ b/jitlog/parser.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 JITLOG_MIN_VERSION = 1
 JITLOG_VERSION = 1
 
-class ParseContext(object):
+class ParseContext:
     def __init__(self, forest):
         self.descrs = defaultdict(list)
         self.forest = forest

--- a/jitlog/prettyprinter.py
+++ b/jitlog/prettyprinter.py
@@ -1,6 +1,6 @@
 from colorama import init, deinit, Fore, Back, Style
 
-class PrettyPrinter(object):
+class PrettyPrinter:
     def __enter__(self):
         pass
 

--- a/jitlog/query.py
+++ b/jitlog/query.py
@@ -2,7 +2,7 @@ import functools
 
 
 
-class Filter(object):
+class Filter:
     def __and__(self, o):
         assert isinstance(o, Filter)
         return AndFilter(self, o)
@@ -82,7 +82,7 @@ QUERY_API = {
 }
 
 
-class Query(object):
+class Query:
     def __init__(self, text):
         self.query_str = text
         self.forest = None

--- a/jitlog/test/data/code2.py
+++ b/jitlog/test/data/code2.py
@@ -1,3 +1,3 @@
-class Name(object): # must be line 1
+class Name: # must be line 1
     def __init__(self): # note the following line has indent 7
        self.unique = False

--- a/jitlog/test/test_encoding.py
+++ b/jitlog/test/test_encoding.py
@@ -4,8 +4,6 @@ import pytest
 from jitlog.objects import (TraceForest, MergePoint, FlatOp)
 from jitlog import constants as const
 
-PY3 = sys.version_info[0] >= 3
-
 @pytest.mark.parametrize('encoding,text,decoded,bom',
     [('ascii',   b'a!1%$', u'a!1%$', None),
      ('utf-8',   b"\x41\xE2\x89\xA2\xCE\x91\x2E", u'A≢Α.', None),
@@ -30,7 +28,4 @@ def test_merge_point_extract_source_code(encoding,text,decoded,bom,tmpdir):
     trace.add_instr(MergePoint({0x1: str(file), 0x2: 2}))
     forest.extract_source_code_lines()
     line = forest.source_lines[str(file)][2]
-    if PY3:
-        assert line == (0, "print(\"" + decoded + "\")")
-    else:
-        assert line == (0, "print(\"" + text + "\")")
+    assert line == (0, "print(\"" + decoded + "\")")

--- a/jitlog/test/test_jitlog.py
+++ b/jitlog/test/test_jitlog.py
@@ -1,4 +1,4 @@
-import struct, py, sys
+import struct, sys
 import pytest
 from vmprof import reader
 from jitlog import constants as const

--- a/jitlog/test/test_jitlog.py
+++ b/jitlog/test/test_jitlog.py
@@ -12,8 +12,6 @@ from vmprof.test.test_reader import FileObj
 from vmprof.test.test_run import FileObjWrapper, BufferTooSmallError
 import vmprof
 
-PY3 = sys.version_info[0] >= 3
-
 def construct_forest(fileobj, version=1, forest=None):
     if forest is None:
         forest = TraceForest(version)
@@ -160,15 +158,12 @@ def test_merge_point_encode():
         assert binary == partb + parta
 
 def test_iter_ranges():
-    r = lambda a,b: list(range(a,b))
-    if PY3:
-        r = range
     assert list(iter_ranges([])) == []
-    assert list(iter_ranges([1])) == [r(1,2)]
-    assert list(iter_ranges([5,7])) == [r(5,8)]
-    assert list(iter_ranges([14,25,100])) == [r(14,26),r(100,101)]
-    assert list(iter_ranges([-1,2])) == [r(-1,2+1)]
-    assert list(iter_ranges([0,1,100,101,102,300,301])) == [r(0,2),r(100,103),r(300,302)]
+    assert list(iter_ranges([1])) == [range(1,2)]
+    assert list(iter_ranges([5,7])) == [range(5,8)]
+    assert list(iter_ranges([14,25,100])) == [range(14,26),range(100,101)]
+    assert list(iter_ranges([-1,2])) == [range(-1,2+1)]
+    assert list(iter_ranges([0,1,100,101,102,300,301])) == [range(0,2),range(100,103),range(300,302)]
 
 def test_read_jitlog_counter():
     forest = TraceForest(1)

--- a/jitlog/test/test_jitlog.py
+++ b/jitlog/test/test_jitlog.py
@@ -203,7 +203,7 @@ def test_point_in_trace():
     assert trace.counter == 10
     assert trace.point_counters[1] == 20
 
-class FakeOp(object):
+class FakeOp:
     def __init__(self, i):
         self.index = i
 

--- a/jitlog/test/test_query.py
+++ b/jitlog/test/test_query.py
@@ -2,7 +2,7 @@ from jitlog.objects import (TraceForest, FlatOp, MergePoint)
 from jitlog import constants as c
 from jitlog import query
 
-class TestQueries(object):
+class TestQueries:
     def q(self, forest, text):
         return query.new_unsafe_query(text)(forest)
 

--- a/setup.py
+++ b/setup.py
@@ -102,11 +102,6 @@ else:
                            extra_compile_args=extra_compile_args,
                            libraries=libraries)]
 
-if sys.version_info[:2] >= (3, 3):
-    extra_install_requires = []
-else:
-    extra_install_requires = ["backports.shutil_which"]
-
 setup(
     name='vmprof',
     author='vmprof team',
@@ -121,7 +116,7 @@ setup(
         'requests',
         'pytz',
         'colorama',
-    ] + extra_install_requires,
+    ],
     python_requires='>=3.6, <3.12',
     tests_require=['pytest','cffi','hypothesis'],
     entry_points = {

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,6 @@ setup(
     cmdclass={'build_py': vmprof_build},
     install_requires=[
         'requests',
-        'six',
         'pytz',
         'colorama',
     ] + extra_install_requires,

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ import platform
 
 IS_PYPY = '__pypy__' in sys.builtin_module_names
 
-class vmprof_build(build_py, object):
+class vmprof_build(build_py):
     def run(self):
-        super(vmprof_build, self).run()
+        super().run()
 
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -66,13 +66,13 @@ else:
            'src/libbacktrace/sort.c',
         ]
         # configure libbacktrace!!
-        class vmprof_build(build_py, object):
+        class vmprof_build(build_py):
             def run(self):
                 orig_dir = os.getcwd()
                 os.chdir(os.path.join(BASEDIR, "src", "libbacktrace"))
                 subprocess.check_call(["./configure"])
                 os.chdir(orig_dir)
-                super(vmprof_build, self).run()
+                super().run()
 
     else:
         raise NotImplementedError("platform '%s' is not supported!" % sys.platform)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,3 @@
-six
 requests
 backports.shutil_which
 cffi

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,4 +5,3 @@ hypothesis
 colorama
 pytz
 attrs
-py

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,4 @@
 requests
-backports.shutil_which
 cffi
 pytest
 hypothesis

--- a/vmprof/__init__.py
+++ b/vmprof/__init__.py
@@ -37,7 +37,7 @@ def disable():
                         _vmprof.write_all_code_objects(l.dedup)
         finally:
             _vmprof.disable()
-    except IOError as e:
+    except OSError as e:
         raise Exception("Error while writing profile: " + str(e))
 
 def _is_native_enabled(native):

--- a/vmprof/__init__.py
+++ b/vmprof/__init__.py
@@ -1,9 +1,6 @@
 import os
 import sys
-try:
-    from shutil import which
-except ImportError:
-    from backports.shutil_which import which
+from shutil import which
 
 import _vmprof
 

--- a/vmprof/__init__.py
+++ b/vmprof/__init__.py
@@ -12,7 +12,6 @@ from vmprof.stats import Stats
 from vmprof.profiler import Profiler, read_profile
 
 
-PY3  = sys.version_info[0] >= 3
 IS_PYPY = '__pypy__' in sys.builtin_module_names
 
 # it's not a good idea to use a "round" default sampling period, else we risk

--- a/vmprof/cli.py
+++ b/vmprof/cli.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import argparse
 import sys
-from six.moves import configparser
+import configparser
 
 
 def build_argparser():

--- a/vmprof/cli.py
+++ b/vmprof/cli.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import argparse
 import sys
 import configparser
@@ -108,7 +106,7 @@ def parse_args(argv):
     return args
 
 
-class IniParser(object):
+class IniParser:
 
     def __init__(self, f):
         self.ini_parser = configparser.ConfigParser()

--- a/vmprof/profiler.py
+++ b/vmprof/profiler.py
@@ -8,7 +8,7 @@ from vmprof.reader import _read_prof
 class VMProfError(Exception):
     pass
 
-class ProfilerContext(object):
+class ProfilerContext:
     done = False
 
     def __init__(self, name, period, memory, native, real_time):
@@ -50,7 +50,7 @@ def read_profile(prof_file):
     return s
 
 
-class Profiler(object):
+class Profiler:
     ctx = None
 
     def __init__(self):

--- a/vmprof/reader.py
+++ b/vmprof/reader.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import struct
 import sys
@@ -64,7 +63,7 @@ def gunzip(fileobj):
         fileobj = io.BufferedReader(gzip.GzipFile(fileobj=fileobj))
     return fileobj
 
-class ReaderStatus(object):
+class ReaderStatus:
     def __init__(self, interp_name, period, version, previous_virtual_ips=None,
                  profile_memory=False, profile_lines=False):
         if previous_virtual_ips is not None:
@@ -85,7 +84,7 @@ def assert_error(condition, error="malformed file"):
     if not condition:
         raise FileReadError(error)
 
-class LogReader(object):
+class LogReader:
     # NOTE be sure to carry along changes in src/symboltable.c for
     # native symbol resolution if something changes in this function
     def __init__(self, fileobj, state):
@@ -344,7 +343,7 @@ class LogReaderDumpNative(LogReader):
             if addr not in self.dedup:
                 self.dedup.add(addr)
 
-class ReaderState(object):
+class ReaderState:
     pass
 
 class LogReaderState(ReaderState):
@@ -372,7 +371,7 @@ def _read_prof(fileobj, virtual_ips_only=False):
         return state.virtual_ips
     return state
 
-class FdWrapper(object):
+class FdWrapper:
     """ This wrapper behaves like a file object. Could not find
         an stdlib API function that creates such an object without
         closing it.

--- a/vmprof/reader.py
+++ b/vmprof/reader.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 import os
 import struct
 import sys
-from six.moves import xrange
 import io
 import gzip
 import datetime
@@ -208,12 +207,12 @@ class LogReader(object):
             kinds_and_pcs = self.read_addresses(depth * 2)
             # kinds_and_pcs is a list of [kind1, pc1, kind2, pc2, ...]
             return [wrap_kind(kinds_and_pcs[i], kinds_and_pcs[i+1])
-                    for i in xrange(0, len(kinds_and_pcs), 2)]
+                    for i in range(0, len(kinds_and_pcs), 2)]
         else:
             trace = self.read_addresses(depth)
 
             if self.state.profile_lines:
-                for i in xrange(0, len(trace), 2):
+                for i in range(0, len(trace), 2):
                     # In the line profiling mode even items in the trace are line numbers.
                     # Every line number corresponds to the following frame, represented by an address.
                     trace[i] = -trace[i]

--- a/vmprof/reader.py
+++ b/vmprof/reader.py
@@ -6,9 +6,6 @@ import io
 import gzip
 import datetime
 
-PY3  = sys.version_info[0] >= 3
-
-
 MARKER_STACKTRACE = b'\x01'
 MARKER_VIRTUAL_IP = b'\x02'
 MARKER_TRAILER = b'\x03'
@@ -104,20 +101,19 @@ class LogReader(object):
     def detect_file_sizes(self):
         self.fileobj.seek(0, os.SEEK_SET)
         firstbytes = self.read(8)
-        three = '\x03' if not PY3 else 3
         little = None
-        if firstbytes[4] == three:
+        if firstbytes[4] == 3:
             little = True
             self.setup_once(little_endian=little, word_size=4, addr_size=4)
-        elif firstbytes[7] == three:
+        elif firstbytes[7] == 3:
             little = False
             self.setup_once(little_endian=little, word_size=4, addr_size=4)
         else:
             firstbytes = self.read(8)
-            if firstbytes[0] == three:
+            if firstbytes[0] == 3:
                 little = True
                 self.setup_once(little_endian=little, word_size=8, addr_size=8)
-            elif firstbytes[7] == three:
+            elif firstbytes[7] == 3:
                 little = False
                 self.setup_once(little_endian=little, word_size=8, addr_size=8)
             else:
@@ -171,8 +167,7 @@ class LogReader(object):
         s.interp_name = fileobj.read(lgt)
         if s.interp_name == b'pypy':
             s.profile_rpython = True
-        if PY3:
-            s.interp_name = s.interp_name.decode()
+        s.interp_name = s.interp_name.decode()
 
     def read_addr(self):
         if self.addr_size == 8:
@@ -195,10 +190,9 @@ class LogReader(object):
 
     def read_string(self):
         cnt = self.read_word()
-        bytes = self.read(cnt)
-        if PY3:
-            return bytes.decode('utf-8')
-        return bytes
+        result = self.read(cnt)
+        result = result.decode('utf-8')
+        return result
 
     def read_trace(self, depth):
         if self.state.profile_rpython:

--- a/vmprof/show.py
+++ b/vmprof/show.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import inspect
 import linecache
@@ -22,7 +21,7 @@ class color(str):
     def __new__(cls, content, color, bold=False):
         return "%s%s%s%s" % (color, cls.BOLD if bold else "", content, cls.END)
 
-class AbstractPrinter(object):
+class AbstractPrinter:
     def show(self, profile):
         """
         Read and display a vmprof profile file.

--- a/vmprof/stats.py
+++ b/vmprof/stats.py
@@ -3,7 +3,7 @@ from vmprof.reader import AssemblerCode, JittedCode, NativeCode
 class EmptyProfileFile(Exception):
     pass
 
-class Stats(object):
+class Stats:
     def __init__(self, profiles, adr_dict=None, jit_frames=None, interp=None,
                  meta=None, start_time=None, end_time=None, state=None):
         self.profiles = profiles
@@ -172,7 +172,7 @@ class Stats(object):
         return first_top
 
 
-class Node(object):
+class Node:
     """ children is a dict of addr -> Node
     """
     _self_count = None

--- a/vmprof/stats.py
+++ b/vmprof/stats.py
@@ -1,4 +1,3 @@
-import six
 from vmprof.reader import AssemblerCode, JittedCode, NativeCode
 
 class EmptyProfileFile(Exception):
@@ -58,7 +57,7 @@ class Stats(object):
         return self.meta.get('argv', '')
 
     def getmeta(self, key, default):
-        return self.meta.get(key, default) 
+        return self.meta.get(key, default)
 
     def display(self, no):
         prof = self.profiles[no][0]
@@ -77,7 +76,7 @@ class Stats(object):
                     current_iter[addr] = None
 
     def top_profile(self):
-        return [(self._get_name(k), v) for (k, v) in six.iteritems(self.functions)]
+        return [(self._get_name(k), v) for (k, v) in self.functions.items()]
 
     def _get_name(self, addr):
         if self.adr_dict is not None:
@@ -203,7 +202,7 @@ class Node(object):
         return json.dumps(self._serialize())
 
     def _serialize(self):
-        chld = [ch._serialize() for ch in six.itervalues(self.children)]
+        chld = [ch._serialize() for ch in self.children.items()]
         # if we don't make str() of addr here, JS does its
         # int -> float -> int losy convertion without
         # any warning
@@ -211,21 +210,21 @@ class Node(object):
 
     def _rec_count(self):
         c = 1
-        for x in six.itervalues(self.children):
+        for x in self.children.values():
             c += x._rec_count()
         return c
 
     def walk(self, callback):
         callback(self)
-        for c in six.itervalues(self.children):
+        for c in self.children.values():
             c.walk(callback)
 
     def cumulative_meta(self, d=None):
         if d is None:
             d = {}
-        for c in six.itervalues(self.children):
+        for c in self.children.values():
             c.cumulative_meta(d)
-        for k, v in six.iteritems(self.meta):
+        for k, v in self.meta.items():
             d[k] = d.get(k, 0) + v
         return d
 
@@ -241,7 +240,7 @@ class Node(object):
         if self._self_count is not None:
             return self._self_count
         self._self_count = self.count
-        for elem in six.itervalues(self.children):
+        for elem in self.children.values():
             self._self_count -= elem.count
         return self._self_count
 

--- a/vmprof/test/test_c_source.py
+++ b/vmprof/test/test_c_source.py
@@ -9,7 +9,7 @@ IS_PYPY = '__pypy__' in sys.builtin_module_names
 
 sample = None
 @pytest.mark.skipif("sys.platform == 'win32' or IS_PYPY")
-class TestStack(object):
+class TestStack:
     def setup_class(cls):
         stack_ffi = FFI()
         stack_ffi.cdef("""

--- a/vmprof/test/test_c_symboltable.py
+++ b/vmprof/test/test_c_symboltable.py
@@ -66,7 +66,7 @@ if sys.platform != 'win32':
     ffi.compile(verbose=True)
 
 @pytest.mark.skipif("sys.platform == 'win32'")
-class TestSymbolTable(object):
+class TestSymbolTable:
     def setup_class(cls):
         from vmprof.test import _test_symboltable as clib
         cls.lib = clib.lib

--- a/vmprof/test/test_reader.py
+++ b/vmprof/test/test_reader.py
@@ -5,7 +5,7 @@ from vmprof.reader import (FileReadError, MARKER_HEADER)
 from vmprof.test.test_run import (read_one_marker, read_header,
         BufferTooSmallError, FileObjWrapper)
 
-class FileObj(object):
+class FileObj:
     def __init__(self, lst=None):
         self.s = b''
         if lst is None:

--- a/vmprof/test/test_run.py
+++ b/vmprof/test/test_run.py
@@ -28,7 +28,7 @@ class BufferTooSmallError(Exception):
     def get_buf(self):
         return b"".join(self.args[0])
 
-class FileObjWrapper(object):
+class FileObjWrapper:
     def __init__(self, fileobj, buffer_so_far=None):
         self._fileobj = fileobj
         self._buf = []
@@ -459,7 +459,7 @@ def test_vmprof_show():
     pp.show(tmpfile.name)
 
 @pytest.mark.skipif("sys.platform == 'win32' or sys.platform == 'darwin'")
-class TestNative(object):
+class TestNative:
     def setup_class(cls):
         ffi = FFI()
         ffi.cdef("""

--- a/vmprof/test/test_run.py
+++ b/vmprof/test/test_run.py
@@ -9,7 +9,6 @@ import gzip
 import time
 import pytz
 import vmprof
-import six
 from cffi import FFI
 from datetime import datetime
 import requests
@@ -453,8 +452,8 @@ def test_line_profiling():
     def walk(tree):
         assert len(tree.lines) >= len(tree.children)
 
-        for v in six.itervalues(tree.children):
-                walk(v)
+        for v in tree.children.values():
+            walk(v)
 
     stats = read_profile(tmpfile.name)
     walk(stats.get_tree())

--- a/vmprof/test/test_run.py
+++ b/vmprof/test/test_run.py
@@ -52,11 +52,6 @@ class FileObjWrapper(object):
         return s
 
 
-if sys.version_info.major == 3:
-    xrange = range
-    PY3K = True
-else:
-    PY3K = False
 if hasattr(os, 'uname') and os.uname().machine == 'ppc64le':
     PPC64LE = True
 else:
@@ -69,7 +64,7 @@ else:
 
 def function_foo():
     for k in range(1000):
-        l = [a for a in xrange(COUNT)]
+        l = [a for a in range(COUNT)]
     return l
 
 def function_bar():
@@ -197,11 +192,8 @@ def test_nested_call():
         t = t['']
     assert len(t.children) == 1
     assert 'function_foo' in t[''].name
-    if PY3K:
-        assert len(t[''].children) == 1
-        assert '<listcomp>' in t[''][''].name
-    else:
-        assert len(t[''].children) == 0
+    assert len(t[''].children) == 1
+    assert '<listcomp>' in t[''][''].name
 
 def test_multithreaded():
     if '__pypy__' in sys.builtin_module_names:
@@ -213,7 +205,7 @@ def test_multithreaded():
 
     def f():
         for k in range(1000):
-            l = [a for a in xrange(COUNT)]
+            l = [a for a in range(COUNT)]
         finished.append("foo")
 
     threads = [threading.Thread(target=f), threading.Thread(target=f)]
@@ -250,7 +242,7 @@ def test_memory_measurment():
     def function_foo():
         all = []
         for k in range(1000):
-            all.append([a for a in xrange(COUNT)])
+            all.append([a for a in range(COUNT)])
         return all
 
     def function_bar():
@@ -413,9 +405,7 @@ def read_one_marker(fileobj, status, buffer_so_far=None):
         status.profiles.append((trace, 1, thread_id, mem_in_kb))
     elif marker == MARKER_VIRTUAL_IP or marker == MARKER_NATIVE_SYMBOLS:
         unique_id = read_addr(fileobj)
-        name = read_string(fileobj)
-        if PY3K:
-            name = name.decode()
+        name = read_string(fileobj).decode()
         status.virtual_ips[unique_id] = name
     elif marker == MARKER_META:
         read_string(fileobj)

--- a/vmprof/test/test_stats.py
+++ b/vmprof/test/test_stats.py
@@ -2,7 +2,6 @@ import json
 import zlib
 
 import pytest
-import six
 
 import vmprof
 from vmprof.stats import Node, Stats, JittedCode, AssemblerCode

--- a/vmprofdemo.py
+++ b/vmprofdemo.py
@@ -2,13 +2,13 @@ import sys
 import random
 
 
-class Node(object):
+class Node:
     def __init__(self, right, left):
         self.left = left
         self.right = right
 
 
-class Digit(object):
+class Digit:
     def __init__(self, v):
         self.v = v
 

--- a/vmshare/binary.py
+++ b/vmshare/binary.py
@@ -11,8 +11,6 @@ else:
     ADDR_SIZE = 4
     ADDR_CHAR = 'l'
 
-PY3 = sys.version_info[0] >= 3
-
 def read_word(fileobj):
     """Read a single long from `fileobj`."""
     b = fileobj.read(WORD_SIZE)
@@ -25,26 +23,19 @@ def read_addr(fileobj):
 
 def read_addresses(fileobj, count):
     """Read `addresses` longs from `fileobj`."""
-    if PY3:
-        r = array.array(ADDR_CHAR)
-        b = fileobj.read(ADDR_SIZE * count)
-        r.frombytes(b)
-    else:
-        r = [struct.unpack(ADDR_CHAR, fileobj.read(ADDR_SIZE))[0] \
-             for i in range(count)]
+    r = array.array(ADDR_CHAR)
+    b = fileobj.read(ADDR_SIZE * count)
+    r.frombytes(b)
+
     return r
 
 def read_byte(fileobj):
     value = fileobj.read(1)
-    if PY3:
-        return value[0]
-    return ord(value[0])
+    return value[0]
 
 def read_char(fileobj):
     value = fileobj.read(1)
-    if PY3:
-        return chr(value[0])
-    return value[0]
+    return chr(value[0])
 
 def read_bytes(fileobj):
     lgt = int(struct.unpack('<i', fileobj.read(4))[0])
@@ -54,8 +45,7 @@ def read_string(fileobj, little_endian=False):
     if little_endian:
         lgt = int(struct.unpack('<i', fileobj.read(4))[0])
         data = fileobj.read(lgt)
-        if PY3:
-            data = data.decode('utf-8')
+        data = data.decode('utf-8')
         return data
     else:
         lgt = int(struct.unpack('l', fileobj.read(WORD_SIZE))[0])
@@ -101,8 +91,7 @@ def encode_le_u64(value):
     return struct.pack('<Q', value)
 
 def encode_str(val):
-    if PY3:
-        val = val.encode()
+    val = val.encode()
     return struct.pack("<i", len(val)) + val
 
 

--- a/vmshare/service.py
+++ b/vmshare/service.py
@@ -35,7 +35,7 @@ def compress_file(filename):
                 zipfd.write(chunk)
     return name
 
-class Service(object):
+class Service:
     FILE_CPU_PROFILE = 'cpu'
     FILE_MEM_PROFILE = 'mem'
     FILE_JIT_PROFILE = 'jit'

--- a/vmshare/service.py
+++ b/vmshare/service.py
@@ -12,8 +12,6 @@ import jitlog
 import gzip
 import warnings
 
-PY3 = sys.version_info[0] >= 3
-
 class ServiceException(Exception):
     pass
 


### PR DESCRIPTION
This started just to remove the `six` dependency, but includes some additional cleanups.

In `setup.py` `vmprof` advertises `python_requires='>=3.6, <3.12'` so these should all be safe. Let me know if you want them split up or anything else!