### PR TITLE
add guards for PyPy

### DIFF
--- a/src/vmp_stack.c
+++ b/src/vmp_stack.c
@@ -14,11 +14,6 @@
 #include "vmprof.h"
 #include "compat.h"
 
-#if PY_VERSION_HEX >= 0x030b00f0 /* >= 3.11 */
-#include "internal/pycore_frame.h"
-#include "populate_frames.h"
-#endif
-
 #ifdef VMP_SUPPORTS_NATIVE_PROFILING
 
 #if defined(VMPROF_LINUX) || defined(VMPROF_BSD)

--- a/src/vmp_stack.h
+++ b/src/vmp_stack.h
@@ -2,12 +2,14 @@
 
 #include "vmprof.h"
 
-#if PY_VERSION_HEX >= 0x030b00f0 /* >= 3.11 */
-#include "internal/pycore_frame.h"
-#include "populate_frames.h"
+#ifndef RPYTHON_VMPROF
+  #if PY_VERSION_HEX >= 0x030b00f0 /* >= 3.11 */
+  #include "internal/pycore_frame.h"
+  #include "populate_frames.h"
+  #endif
 #endif
 
-#if PY_VERSION_HEX >= 0x030B0000 /* >= 3.11 */
+#if PY_VERSION_HEX >= 0x030B0000  && !defined(RPYTHON_VMPROF) /* >= 3.11 */
     int vmp_walk_and_record_stack(_PyInterpreterFrame * frame, void **data,
                                     int max_depth, int signal, intptr_t pc);
 #else

--- a/src/vmprof_unix.c
+++ b/src/vmprof_unix.c
@@ -1,7 +1,9 @@
 #include "vmprof_unix.h"
 
-#if PY_VERSION_HEX >= 0x030b00f0 /* >= 3.11 */
-#include "populate_frames.h"
+#ifndef RPYTHON_VMPROF
+  #if PY_VERSION_HEX >= 0x030b00f0 /* >= 3.11 */
+  #include "populate_frames.h"
+  #endif
 #endif
 
 #ifdef VMPROF_UNIX
@@ -479,7 +481,7 @@ int vmprof_register_virtual_function(char *code_name, intptr_t code_uid,
     return 0;
 }
 
-#if PY_VERSION_HEX < 0x030900B1 /* < 3.9 */
+#if PY_VERSION_HEX < 0x030900B1  && ! defined(RPYTHON_VMPROF) /* < 3.9 */
 static inline PyFrameObject* PyThreadState_GetFrame(PyThreadState *tstate)
 {
     Py_XINCREF(tstate->frame);
@@ -511,8 +513,8 @@ int get_stack_trace(PY_THREAD_STATE_T * current, void** result, int max_depth, i
     frame = PyThreadState_GetFrame(current);
 #endif
    
+#endif /* RPYTHON_VMPROF */
 
-#endif
     if (frame == NULL) {
 #if DEBUG
         fprintf(stderr, "WARNING: get_stack_trace, frame is NULL\n");
@@ -522,7 +524,7 @@ int get_stack_trace(PY_THREAD_STATE_T * current, void** result, int max_depth, i
 
     int res = vmp_walk_and_record_stack(frame, result, max_depth, 1, pc);
 
-#if PY_VERSION_HEX < 0x030B0000 /* < 3.11 */
+#if PY_VERSION_HEX < 0x030B0000 && ! defined(RPYTHON_VMPROF) /* < 3.11 */
     Py_XDECREF(frame);
 #endif
 

--- a/src/vmprof_win.c
+++ b/src/vmprof_win.c
@@ -1,8 +1,10 @@
 #include "vmprof_win.h"
 
-#if PY_VERSION_HEX >= 0x030b00f0 /* >= 3.11 */
-#include "internal/pycore_frame.h"
-#include "populate_frames.h"
+#ifndef RPYTHON_VMPROF
+  #if PY_VERSION_HEX >= 0x030b00f0 /* >= 3.11 */
+  #include "internal/pycore_frame.h"
+  #include "populate_frames.h"
+  #endif
 #endif
 
 volatile int thread_started = 0;
@@ -58,7 +60,7 @@ int vmp_write_all(const char *buf, size_t bufsize)
     return 0;
 }
 
-#if PY_VERSION_HEX < 0x030900B1 /* < 3.9 */
+#if PY_VERSION_HEX < 0x030900B1 && not defined(RPYTHON_VMPROF) /* < 3.9 */
 static inline PyFrameObject* PyThreadState_GetFrame(PyThreadState *tstate)
 {
     Py_XINCREF(tstate->frame);


### PR DESCRIPTION
Add guard code to avoid cpython APIs when RPYTHON_VMPROF is defined (i.e. on PyPY) and also remove redundant includes